### PR TITLE
Implement show-functions and show-function tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A TypeScript implementation of a Model Context Protocol (MCP) server for Azure D
   - Initialize connection to ADX clusters
   - List tables in databases
   - Show table schemas
+  - List functions in databases
+  - Get code for functions
   - Execute KQL queries
 - **Schema Caching**: Caches table schemas to reduce redundant calls
 - **Telemetry**: OpenTelemetry integration for activity tracking
@@ -79,6 +81,27 @@ Add this JSON to the `cline_mcp_settings.json` file:
 }
 ```
 
+### Visual Studio Code Insiders configuration
+
+Add this JSON stanza to the `settings.json` file:
+
+```JSON
+    "mcp": {
+        "servers": {
+            "kusto-mcp": {
+                "type": "stdio",
+                "command": "npm",
+                "args": [
+                    "--prefix",
+                    "<path to the kusto-mcp source directory>",
+                    "run",
+                    "start",
+                    "--silent"
+                ]
+            }
+        }
+    },
+
 ## Usage
 
 ### Running the Server
@@ -117,6 +140,14 @@ The server provides the following MCP tools:
    - Runs KQL queries and returns results
    - Parameters:
      - `query`: The query to execute
+
+5. **show-functions**
+   - Lists all functions in the given database
+
+6. **show-function**
+   - Provides detailed information on a given function, including its source code
+   - Parameters:
+     - `functionName`: The name of the function to get informationabout
 
 ### AI Assistant Guidance
 

--- a/src/operations/kusto/index.ts
+++ b/src/operations/kusto/index.ts
@@ -1,12 +1,13 @@
 import { KustoConnection } from "./connection.js";
 import { executeManagementCommand, executeQuery } from "./queries.js";
-import { showTable, showTables } from "./tables.js";
+import { showFunction, showFunctions, showTable, showTables } from "./tables.js";
 
 /**
  * Export all Kusto operations
  */
 export {
-  executeManagementCommand, executeQuery, KustoConnection, showTable, showTables
+  executeManagementCommand, executeQuery, KustoConnection, showTable, showTables,
+  showFunctions, showFunction
 };
 
 /**
@@ -16,6 +17,8 @@ export default {
   KustoConnection,
   showTables,
   showTable,
+  showFunctions,
+  showFunction,
   executeQuery,
   executeManagementCommand
 };

--- a/src/operations/kusto/tables.ts
+++ b/src/operations/kusto/tables.ts
@@ -1,7 +1,7 @@
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 import { KustoQueryError, KustoResourceNotFoundError } from "../../common/errors.js";
 import { safeLog } from "../../common/utils.js";
-import { KustoTableListItem, KustoTableSchema } from "../../types/kusto-interfaces.js";
+import { KustoTableListItem, KustoTableSchema, KustoFunctionSchema, KustoFunctionListItem } from "../../types/kusto-interfaces.js";
 import { KustoConnection } from "./connection.js";
 
 // Create a tracer for this module
@@ -98,7 +98,7 @@ export async function showTable(connection: KustoConnection, tableName: string):
  * @param connection The Kusto connection
  * @returns A list of functions
  */
-export async function showFunctions(connection: KustoConnection): Promise<any> {
+export async function showFunctions(connection: KustoConnection): Promise<KustoFunctionListItem[]> {
   return tracer.startActiveSpan("showFunctions", async (span) => {
     try {
       if (!connection.isInitialized()) {
@@ -126,6 +126,52 @@ export async function showFunctions(connection: KustoConnection): Promise<any> {
       });
 
       throw new KustoQueryError(`Failed to list functions: ${errorMessage}`);
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Get the details of a specific function
+ * 
+ * @param connection The Kusto connection
+ * @param functionName The name of the function
+ * @returns The function details
+ */
+export async function showFunction(connection: KustoConnection, functionName: string): Promise<KustoFunctionSchema> {
+  return tracer.startActiveSpan("showFunction", async (span) => {
+    try {
+      span.setAttribute("functionName", functionName);
+      
+      const database = connection.getDatabase();
+      span.setAttribute("database", database);
+      
+      safeLog(`Getting details for function: ${functionName} in database: ${database}`);
+      
+      if (!connection.isInitialized()) {
+        throw new KustoQueryError("Connection not initialized");
+      }
+      
+      // Execute the query to get the function details
+      const result = await connection.executeQuery(database, `.show function ${functionName}`);
+      span.setStatus({ code: SpanStatusCode.OK });
+      
+      return result;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      safeLog(`Failed to get function details: ${errorMessage}`);
+      
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: errorMessage
+      });
+      
+      if (error instanceof KustoResourceNotFoundError) {
+        throw error;
+      }
+      
+      throw new KustoQueryError(`Failed to get function details: ${errorMessage}`);
     } finally {
       span.end();
     }

--- a/src/operations/kusto/tables.ts
+++ b/src/operations/kusto/tables.ts
@@ -110,8 +110,9 @@ export async function showFunctions(connection: KustoConnection): Promise<any> {
 
       safeLog(`Listing functions in database: ${database}`);
 
-      // Execute the query to list functions
-      const result = await connection.executeQuery(database, ".show functions");
+      // Execute the query to list functions.
+      // Get only the function name and docstring to reduce token consumption and focus the agent.
+      const result = await connection.executeQuery(database, ".show functions | project Name, DocString");
       span.setStatus({ code: SpanStatusCode.OK });
 
       return result;

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import { formatKustoMcpError, isKustoMcpError } from "./common/errors.js";
 import { safeLog } from "./common/utils.js";
 import { executeQuery, KustoConnection, showTable, showTables } from "./operations/kusto/index.js";
 import { KustoConfig, validateConfig } from "./types/config.js";
+import { showFunctions } from "./operations/kusto/tables.js";
 
 /**
  * Detailed description of the Kusto MCP server for AI assistants
@@ -23,6 +24,7 @@ Tools:
 - "initialize-connection": Creates connection to an ADX cluster
 - "show-tables": list tables in the current database
 - "show-table": show the table schema columns
+- "show-functions": list functions in the current database, including their code
 - "execute-query": Runs KQL queries and returns results
 </mcp>
 
@@ -35,6 +37,7 @@ Tools:
 2. Database Exploration:
    - When user mentions data analysis needs, identify target database
    - Use show-tables to fetch tables information from the current database, and show-table to fetch table schema
+   - Use show-functions to fetch functions information from the current database, including their code in the Body column.
    - Present schema details in user-friendly format
 
 3. Query Execution:
@@ -99,6 +102,7 @@ const InitializeConnectionSchema = z.object({
 });
 
 const ShowTablesSchema = z.object({});
+const ShowFunctionsSchema = z.object({});
 
 const ShowTableSchema = z.object({
   tableName: z.string().describe("The name of the table to get the schema for")
@@ -159,6 +163,11 @@ export function createKustoServer(config: KustoConfig): Server {
           description: "Runs KQL queries and returns results",
           inputSchema: zodToJsonSchema(ExecuteQuerySchema),
         },
+        {
+          name: "show-functions",
+          description: "List functions in the current database, including their code",
+          inputSchema: zodToJsonSchema(ShowFunctionsSchema),
+        },
       ],
     };
   });
@@ -217,6 +226,22 @@ export function createKustoServer(config: KustoConfig): Server {
           }
           
           const result = await showTable(connection, args.tableName);
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          };
+        }
+
+        case "show-functions": {
+          ShowFunctionsSchema.parse(request.params.arguments);
+          // Check if the connection is initialized
+          if (!connection) {
+            throw new McpError(
+              ErrorCode.InvalidRequest,
+              "Connection not initialized. Please call initialize-connection first."
+            );
+          }
+
+          const result = await showFunctions(connection);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
           };

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,7 +38,7 @@ Tools:
 2. Database Exploration:
    - When user mentions data analysis needs, identify target database
    - Use show-tables to fetch tables information from the current database, and show-table to fetch table schema
-   - Use show-functions to fetch functions information from the current database, including their code in the Body column.
+   - Use show-functions to fetch functions information from the current database, and show-function to fetch function details (including code and parameters)
    - Present schema details in user-friendly format
 
 3. Query Execution:
@@ -170,12 +170,12 @@ export function createKustoServer(config: KustoConfig): Server {
         },
         {
           name: "show-functions",
-          description: "List functions in the current database, including their code",
+          description: "List functions in the current database",
           inputSchema: zodToJsonSchema(ShowFunctionsSchema),
         },
         {
           name: "show-function",
-          description: "Show details of a specific function",
+          description: "Show details of a specific function, including its code and parameters",
           inputSchema: zodToJsonSchema(ShowFunctionSchema),
         },
       ],

--- a/src/types/kusto-interfaces.ts
+++ b/src/types/kusto-interfaces.ts
@@ -162,3 +162,48 @@ export interface KustoTableListItem {
    */
   description?: string;
 }
+
+/**
+ * Interface for a Kusto function list item
+ */
+export interface KustoFunctionListItem {
+  /**
+   * The name of the function
+   */
+  Name: string;
+
+  /**
+   * The function's docstring
+   */
+  DocString?: string;
+}
+
+/**
+ * Interface for a Kusto function schema
+ */
+export interface KustoFunctionSchema {
+  /**
+   * The name of the function
+   */
+  Name: string;
+
+  /**
+   * The parameters of the function
+   */
+  Parameters: string;
+
+  /**
+   * The body of the function
+   */
+  Body: string;
+
+  /**
+   * The folder containing the function
+   */
+  Folder?: string;
+
+  /**
+   * The function's description
+   */
+  DocString?: string;
+}


### PR DESCRIPTION
This PR adds the implementation of the `show-function` and `show-functions` MCP tools, allowing agents to interact with Kusto functions and their implementations.

Tested on GitHub Copilot Agent under VSCode insiders, Claude Sonnet 3.5 / 3.7.