### PR TITLE
fix: harden query safety, fix lint coverage, and clean up security debt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,8 @@ KUSTO_MARKDOWN_MAX_CELL_LENGTH=1000 # Maximum characters per table cell (default
 KUSTO_MAX_RESPONSE_LENGTH=12000 # Maximum characters for entire MCP response (default: 12000)
 KUSTO_MIN_RESPONSE_ROWS=1       # Minimum rows to return when data exists (default: 1)
 
+# Safety
+KUSTO_ALLOW_WRITE_OPERATIONS=true # Allow write/management commands (default: true). Set false for read-only.
+
 # OpenTelemetry Configuration
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317/v1/traces

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,9 +17,23 @@ KUSTO_MARKDOWN_MAX_CELL_LENGTH=1000  # Maximum characters per table cell (defaul
 KUSTO_MAX_RESPONSE_LENGTH=12000  # Maximum characters for entire MCP response (default: 12000)
 KUSTO_MIN_RESPONSE_ROWS=1  # Minimum rows to return when data exists (default: 1)
 
+# Safety
+KUSTO_ALLOW_WRITE_OPERATIONS=true  # Allow write/management commands (default: true). Set false for read-only.
+
 # OpenTelemetry Configuration (optional)
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317/v1/traces
 ```
+
+## Read-Only Mode
+
+By default the `execute-query` tool accepts any command, including
+write/management commands (e.g. `.set-or-append`, `.append`, `.ingest`,
+`.drop`, `.create`, `.alter`).
+
+To harden the server — for example when the tool is auto-approved or driven by
+untrusted input — set `KUSTO_ALLOW_WRITE_OPERATIONS=false`. In read-only mode
+only plain KQL queries and `.show` commands are permitted; all other
+control/management commands are rejected.
 
 ## Authentication Methods
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,8 +3,24 @@ import tseslint from 'typescript-eslint';
 
 export default [
   {
+    ignores: ['dist/**', 'coverage/**', 'node_modules/**', '.claude/**'],
+  },
+  {
     files: ['**/*.{js,mjs,cjs,ts,mts,cts}'],
-    languageOptions: { globals: globals.browser },
+    languageOptions: { globals: globals.node },
   },
   ...tseslint.configs.recommended,
+  {
+    rules: {
+      // Tracked tech-debt: the Kusto layer relies on ~34 `any` casts against the
+      // SDK's loosely-typed responses. Surfacing them as warnings keeps them
+      // visible without blocking CI; replacing them with typed wrappers around
+      // primaryResults/_rows is a follow-up.
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "kusto-mcp",
       "version": "1.10.1",
+      "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.10.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -15,9 +16,7 @@
         "@opentelemetry/resources": "^2.6.0",
         "@opentelemetry/sdk-trace-node": "^2.6.0",
         "@opentelemetry/semantic-conventions": "^1.40.0",
-        "axios": "^1.13.6",
         "azure-kusto-data": "^7.0.4",
-        "azure-kusto-ingest": "^7.0.4",
         "markdown-table": "^3.0.4",
         "zod": "^4.3.6"
       },
@@ -135,49 +134,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@azure/core-http-compat": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
-      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@azure/core-client": "^1.10.0",
-        "@azure/core-rest-pipeline": "^1.22.0"
-      }
-    },
-    "node_modules/@azure/core-lro": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
-      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-util": "^1.2.0",
-        "@azure/logger": "^1.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-paging": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
-      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@azure/core-rest-pipeline": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
@@ -217,39 +173,6 @@
         "@azure/abort-controller": "^2.1.2",
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/core-xml": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.0.tgz",
-      "integrity": "sha512-D/sdlJBMJfx7gqoj66PKVmhDDaU6TKA49ptcolxdas29X7AfvLTmfAGLjAcIMBK7UZ2o4lygHIqVckOlQU3xWw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-parser": "^5.0.7",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/data-tables": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/@azure/data-tables/-/data-tables-13.3.2.tgz",
-      "integrity": "sha512-PZ8e4SnCpTQEbQ1P+CK6NR7Vhb86Jw1S1qJi2IcF1ij4qiPX2b4vIemwNPkYg/gZGMqKbxkPvGRpRmEbBYdXuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/core-auth": "^1.9.0",
-        "@azure/core-client": "^1.9.2",
-        "@azure/core-paging": "^1.6.2",
-        "@azure/core-rest-pipeline": "^1.19.0",
-        "@azure/core-tracing": "^1.2.0",
-        "@azure/core-util": "^1.11.0",
-        "@azure/core-xml": "^1.4.4",
-        "@azure/logger": "^1.1.4",
-        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -312,95 +235,35 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.2.tgz",
-      "integrity": "sha512-DoeSJ9U5KPAIZoHsPywvfEj2MhBniQe0+FSpjLUTdWoIkI999GB5USkW6nNEHnIaLVxROHXvprWA1KzdS1VQ4A==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.5.tgz",
+      "integrity": "sha512-RUuewWk9JvWJS5Yiy8/74Lm1rQAWlrU/qg/Bgtk1jIauVRtnb9XKwS5Xg0J+Whwjesq9EVrBIFgQEP8vHxgezA==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.4.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.9.0",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
-    "node_modules/@azure/storage-blob": {
-      "version": "12.31.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.31.0.tgz",
-      "integrity": "sha512-DBgNv10aCSxopt92DkTDD0o9xScXeBqPKGmR50FPZQaEcH4JLQ+GEOGEDv19V5BMkB7kxr+m4h6il/cCDPvmHg==",
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.9.0.tgz",
+      "integrity": "sha512-1MWGjqgUCRAYgLmVFZKp7fs3Rg1TFvIMgywY8ze2olNVvLlJoRThuoziWSDJuwwyJI5L4rnLb9Tyt5D9GvSLPw==",
       "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.9.0",
-        "@azure/core-client": "^1.9.3",
-        "@azure/core-http-compat": "^2.2.0",
-        "@azure/core-lro": "^2.2.0",
-        "@azure/core-paging": "^1.6.2",
-        "@azure/core-rest-pipeline": "^1.19.1",
-        "@azure/core-tracing": "^1.2.0",
-        "@azure/core-util": "^1.11.0",
-        "@azure/core-xml": "^1.4.5",
-        "@azure/logger": "^1.1.4",
-        "@azure/storage-common": "^12.3.0",
-        "events": "^3.0.0",
-        "tslib": "^2.8.1"
-      },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/storage-common": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.3.0.tgz",
-      "integrity": "sha512-/OFHhy86aG5Pe8dP5tsp+BuJ25JOAl9yaMU3WZbkeoiFMHFtJ7tu5ili7qEdBXNW9G5lDB19trwyI6V49F/8iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.9.0",
-        "@azure/core-http-compat": "^2.2.0",
-        "@azure/core-rest-pipeline": "^1.19.1",
-        "@azure/core-tracing": "^1.2.0",
-        "@azure/core-util": "^1.11.0",
-        "@azure/logger": "^1.1.4",
-        "events": "^3.3.0",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@azure/storage-queue": {
-      "version": "12.29.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-queue/-/storage-queue-12.29.0.tgz",
-      "integrity": "sha512-p02H+TbPQWSI/SQ4CG+luoDvpenM+4837NARmOE4oPNOR5vAq7qRyeX72ffyYL2YLnkcyxETh28/bp/TiVIM+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.9.0",
-        "@azure/core-client": "^1.9.3",
-        "@azure/core-http-compat": "^2.0.0",
-        "@azure/core-paging": "^1.6.2",
-        "@azure/core-rest-pipeline": "^1.19.1",
-        "@azure/core-tracing": "^1.2.0",
-        "@azure/core-util": "^1.11.0",
-        "@azure/core-xml": "^1.4.3",
-        "@azure/logger": "^1.1.4",
-        "@azure/storage-common": "^12.2.0",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -409,9 +272,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -419,21 +282,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -460,14 +323,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -490,14 +353,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -604,9 +467,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -628,29 +491,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -733,9 +596,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -743,9 +606,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -753,9 +616,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -778,27 +641,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2161,33 +2024,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2195,14 +2058,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2339,9 +2202,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3387,18 +3250,6 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3616,9 +3467,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
-      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
+      "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -3765,20 +3616,68 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz",
-      "integrity": "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.8.0.tgz",
+      "integrity": "sha512-nZt9OGufioAc3AfoLTqA9bsAeaMJAictYDdI2VcNQ+PmT+3rfKjAZDZvgPfd8VPX0O5Bw1hdQF6kDK8VSpZiWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "2.7.1",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1"
+        "@opentelemetry/context-async-hooks": "2.8.0",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -5504,12 +5403,6 @@
         "pretty-format": "^30.0.0"
       }
     },
-    "node_modules/@types/jsbn": {
-      "version": "1.2.33",
-      "resolved": "https://registry.npmjs.org/@types/jsbn/-/jsbn-1.2.33.tgz",
-      "integrity": "sha512-ZlLkHfu8xqqVFSbCe1FSPtAMUs7LKxk7TPskMb+sI5IbuzqyVqIEt9SVaQfFD2vrFcQunqKAmEBOuBEkoNLw4g==",
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -5521,6 +5414,7 @@
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -5533,12 +5427,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/pako": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
-      "license": "MIT"
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -5546,40 +5434,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/stream-array": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/stream-array/-/stream-array-1.1.4.tgz",
-      "integrity": "sha512-4956VPyHmmWRTI1OGB8rouiPINXqFdiTsLrl9zxfnFLd/TGhcEc6WRvmYJRgQnJ1ETUfVXdF7LPjJEbDwCm3Sg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/stream-to-array": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/stream-to-array/-/stream-to-array-2.3.3.tgz",
-      "integrity": "sha512-fWXKc6enNlT2l0nXZcxHNQvNSg9IIBgHQR1bHfAVjcJD+zlx9F0o6W+qGWerB1eGBszV4+dsge3id4PEp6SptA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
-      "license": "MIT"
-    },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid-validate": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid-validate/-/uuid-validate-0.0.1.tgz",
-      "integrity": "sha512-RbX9q0U00SLoV+l7loYX0Wrtv4QTClBC0QcdNts6x2b5G1HJN8NI9YlS1HNA6THrI9EH3OXSgya6eMQIlDjKFA==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -6345,6 +6203,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
@@ -6464,45 +6323,6 @@
       "engines": {
         "node": ">= 20.0.0"
       }
-    },
-    "node_modules/azure-kusto-ingest": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/azure-kusto-ingest/-/azure-kusto-ingest-7.2.0.tgz",
-      "integrity": "sha512-t++BRyPoV4KGNgQ8b21GrRt+d2bdG1Ul0OYzGHBgI/hzfU1NZ0Dz7aeZl4WcBkXfdCu1t+Kuey+C6NlHoAfUYg==",
-      "license": "ISC",
-      "dependencies": {
-        "@azure/core-util": "^1.13.1",
-        "@azure/data-tables": "^13.3.2",
-        "@azure/storage-blob": "^12.31.0",
-        "@azure/storage-queue": "^12.29.0",
-        "@types/jsbn": "^1.2.33",
-        "@types/pako": "^2.0.4",
-        "@types/stream-array": "^1.1.4",
-        "@types/stream-to-array": "^2.3.3",
-        "@types/tmp": "^0.2.6",
-        "@types/uuid": "^8.3.4",
-        "@types/uuid-validate": "0.0.1",
-        "azure-kusto-data": "^7.2.0",
-        "browserify-zlib": "0.2.0",
-        "buffer": "^6.0.3",
-        "is-ip": "^3.1.0",
-        "pako": "^2.1.0",
-        "stream-array": "^1.1.2",
-        "stream-browserify": "3.0.0",
-        "stream-to-array": "^2.3.0",
-        "tmp-promise": "^3.0.3",
-        "uuid": "^8.3.2",
-        "uuid-validate": "0.0.3"
-      },
-      "engines": {
-        "node": ">= 20.0.0"
-      }
-    },
-    "node_modules/azure-kusto-ingest/node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "license": "(MIT AND Zlib)"
     },
     "node_modules/babel-jest": {
       "version": "30.4.1",
@@ -6662,26 +6482,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -6757,15 +6557,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/browserify-zlib": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-      "license": "MIT",
-      "dependencies": {
-        "pako": "~1.0.5"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -6823,30 +6614,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -6858,12 +6625,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha512-Zy8ZXMyxIT6RMTeY7OP/bDndfj6bwCan7SS98CEndS6deHwWPpseeHlwarNcBim+etXnF9HBc1non5JgDaJU1g==",
       "license": "MIT"
     },
     "node_modules/builtin-status-codes": {
@@ -7463,15 +7224,15 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
+      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
+        "shell-quote": "1.8.4",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -7636,6 +7397,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -8371,9 +8133,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8519,15 +8281,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -8658,12 +8411,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -8757,43 +8510,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -9017,19 +8733,31 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/form-data/node_modules/mime-db": {
@@ -9299,9 +9027,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9441,9 +9169,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -9586,26 +9314,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9735,21 +9443,12 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ipaddr.js": {
@@ -9866,18 +9565,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-ip": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-regex": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -9962,6 +9649,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -10717,10 +10405,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11842,9 +11540,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.11.1.tgz",
-      "integrity": "sha512-asazCodkFdz1ReQzukyzS/DD77uGCIqUFeRG3gtaT8b9UR0ne1m9QOBuMgT72ij1rt7TRrOox4A1WzntMWIuEg==",
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
+      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -11923,8 +11621,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.1",
-        "@npmcli/config": "^10.7.1",
+        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/config": "^10.11.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -11932,37 +11630,37 @@
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
         "@npmcli/run-script": "^10.0.4",
-        "@sigstore/tuf": "^4.0.1",
+        "@sigstore/tuf": "^4.0.2",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^20.0.3",
+        "cacache": "^20.0.4",
         "chalk": "^5.6.2",
         "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
         "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
+        "hosted-git-info": "^9.0.3",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.3",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.4",
-        "libnpmexec": "^10.2.4",
-        "libnpmfund": "^7.0.18",
+        "libnpmdiff": "^8.1.10",
+        "libnpmexec": "^10.3.0",
+        "libnpmfund": "^7.0.24",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.4",
-        "libnpmpublish": "^11.1.3",
+        "libnpmpack": "^9.1.10",
+        "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
-        "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.4",
-        "minimatch": "^10.2.4",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.2.0",
+        "node-gyp": "^12.4.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -11972,16 +11670,16 @@
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.5.0",
+        "pacote": "^21.5.1",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.4",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.16",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -12010,24 +11708,12 @@
       }
     },
     "node_modules/npm/node_modules/@gar/promise-retry": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "retry": "^0.13.1"
-      },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@gar/promise-retry/node_modules/retry": {
-      "version": "0.13.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -12049,7 +11735,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12065,7 +11751,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.1",
+      "version": "9.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12113,7 +11799,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.7.1",
+      "version": "10.11.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12307,7 +11993,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.1.0",
+      "version": "3.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -12316,7 +12002,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -12325,24 +12011,24 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.3",
-        "proc-log": "^6.1.0",
-        "promise-retry": "^2.0.1"
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -12355,13 +12041,13 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -12430,7 +12116,7 @@
       }
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12458,7 +12144,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12470,7 +12156,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "20.0.3",
+      "version": "20.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12484,8 +12170,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^13.0.0",
-        "unique-filename": "^5.0.0"
+        "ssri": "^13.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -12528,7 +12213,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.3",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -12584,7 +12269,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -12600,12 +12285,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -12658,7 +12337,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12733,7 +12412,6 @@
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -12766,7 +12444,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12775,12 +12453,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
@@ -12848,12 +12526,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.4",
+      "version": "8.1.10",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -12867,13 +12545,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.4",
+      "version": "10.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -12890,12 +12568,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.18",
+      "version": "7.0.24",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1"
+        "@npmcli/arborist": "^9.8.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -12915,12 +12593,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.4",
+      "version": "9.1.10",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -12930,7 +12608,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "11.1.3",
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12974,7 +12652,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12990,7 +12668,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.6",
+      "version": "11.5.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -12999,13 +12677,14 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.4",
+      "version": "15.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
         "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
@@ -13021,12 +12700,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -13074,34 +12753,16 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -13182,7 +12843,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.2.0",
+      "version": "12.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -13190,12 +12851,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -13359,7 +13020,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.5.0",
+      "version": "21.5.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13420,7 +13081,7 @@
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -13468,19 +13129,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/promzard": {
       "version": "3.0.1",
       "dev": true,
@@ -13522,15 +13170,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
       "dev": true,
@@ -13539,7 +13178,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13563,17 +13202,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.1.0",
-        "@sigstore/tuf": "^4.0.1",
-        "@sigstore/verify": "^3.1.0"
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -13590,12 +13229,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -13664,7 +13303,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.16",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -13692,13 +13331,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.17",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -13725,7 +13364,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -13759,10 +13398,18 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.26.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "5.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "unique-slug": "^6.0.0"
@@ -13774,7 +13421,6 @@
     "node_modules/npm/node_modules/unique-slug": {
       "version": "6.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
@@ -14077,12 +13723,6 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -14169,21 +13809,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-inside": {
@@ -15953,9 +15578,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16481,69 +16106,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/stream-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/stream-array/-/stream-array-1.1.2.tgz",
-      "integrity": "sha512-1yWdVsMEm/btiMa2YyHiC3mDrtAqlmNNaDRylx2F7KHhm3C4tA6kSR2V9mpeMthv+ujvbl8Kamyh5xaHHdFvyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.1.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/stream-array/node_modules/process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw==",
-      "license": "MIT"
-    },
-    "node_modules/stream-array/node_modules/readable-stream": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-      "integrity": "sha512-NkXT2AER7VKXeXtJNSaWLpWIhmtSE3K2PguaLEeWr4JILghcIKqoLt1A3wHrnpDC5+ekf8gfk1GKWkFXe4odMw==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/stream-array/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "license": "MIT"
-    },
-    "node_modules/stream-browserify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.4",
-        "readable-stream": "^3.5.0"
-      }
-    },
-    "node_modules/stream-browserify/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -16579,15 +16141,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/stream-to-array": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
-      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.1.0"
       }
     },
     "node_modules/string_decoder": {
@@ -16778,18 +16331,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/super-regex": {
       "version": "1.1.0",
@@ -17084,24 +16625,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/tmp-promise": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
-      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tmp": "^0.2.0"
       }
     },
     "node_modules/tmpl": {
@@ -17411,6 +16934,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -17668,12 +17192,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/uuid-validate": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uuid-validate/-/uuid-validate-0.0.3.tgz",
-      "integrity": "sha512-Fykw5U4eZESbq739BeLvEBFRuJODfrlmjx5eJux7W817LjRaq4b7/i4t2zxQmhcX+fAj4nMfRdTzO4tmwLKn0w==",
-      "license": "MIT"
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -17920,9 +17438,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17954,21 +17472,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "git+https://github.com/johnib/kusto-mcp.git"
   },
   "homepage": "https://github.com/johnib/kusto-mcp#readme",
+  "license": "MIT",
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",
     "start": "node dist/index.js",
@@ -30,9 +31,9 @@
     "test:e2e:debug": "DEBUG_SERVER=1 jest --selectProjects e2e",
     "test:all": "jest",
     "test:debug": "DEBUG_SERVER=1 npm run test",
-    "lint": "eslint src/**/*.ts",
-    "lint:check": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix",
+    "lint": "eslint src",
+    "lint:check": "eslint src",
+    "lint:fix": "eslint src --fix",
     "format": "prettier --config .prettierrc.json --write 'src/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts'",
     "format:fix": "prettier --config .prettierrc.json --write 'src/**/*.ts'"
@@ -45,9 +46,7 @@
     "@opentelemetry/resources": "^2.6.0",
     "@opentelemetry/sdk-trace-node": "^2.6.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
-    "axios": "^1.13.6",
     "azure-kusto-data": "^7.0.4",
-    "azure-kusto-ingest": "^7.0.4",
     "markdown-table": "^3.0.4",
     "zod": "^4.3.6"
   },

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -93,6 +93,28 @@ export function isKustoMcpError(error: unknown): error is KustoMcpError {
 }
 
 /**
+ * Extract a human-readable message from an error thrown by the Kusto client.
+ * Kusto surfaces the useful detail under `response.data.error['@message']` (or
+ * `.message`); fall back to the plain Error message otherwise.
+ */
+export function extractKustoErrorMessage(error: unknown): string {
+  let errorMessage = error instanceof Error ? error.message : String(error);
+
+  if (error && typeof error === 'object' && 'response' in error) {
+    const response = (error as { response?: unknown }).response as
+      | { data?: { error?: { '@message'?: string; message?: string } } }
+      | undefined;
+    if (response?.data?.error?.['@message']) {
+      errorMessage = response.data.error['@message'];
+    } else if (response?.data?.error?.message) {
+      errorMessage = response.data.error.message;
+    }
+  }
+
+  return errorMessage;
+}
+
+/**
  * Format a Kusto MCP error for display
  */
 export function formatKustoMcpError(error: KustoMcpError): string {

--- a/src/common/kql-safety.ts
+++ b/src/common/kql-safety.ts
@@ -1,0 +1,86 @@
+import { KustoValidationError } from './errors.js';
+
+/**
+ * Legal Kusto entity-name characters: letters, digits, underscore, dot, dash,
+ * and spaces. Semicolons, colons, pipes, quotes, brackets, parentheses, and
+ * comment markers are NOT valid in entity names, so rejecting everything
+ * outside this set makes it impossible to break out of the intended command
+ * (KQL injection guard). See:
+ * https://learn.microsoft.com/kusto/query/schema-entities/entity-names
+ */
+const SAFE_ENTITY_NAME = /^[A-Za-z0-9_\-. ]+$/;
+
+/**
+ * Validate a table/function/entity name supplied by a tool argument and return
+ * it trimmed. Throws KustoValidationError if it contains characters that aren't
+ * legal in a Kusto identifier.
+ */
+export function validateEntityName(name: string, kind = 'entity'): string {
+  const trimmed = (name ?? '').trim();
+  if (!trimmed || trimmed.length > 1024 || !SAFE_ENTITY_NAME.test(trimmed)) {
+    throw new KustoValidationError(
+      `Invalid ${kind} name: only letters, digits, spaces, '_', '.', and '-' are allowed.`,
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Bracket-quote an entity reference for safe interpolation into a query or
+ * management command, e.g. `My Table` -> `['My Table']`. The name must already
+ * be validated with {@link validateEntityName} so it contains no quotes or
+ * brackets that would need escaping.
+ */
+export function bracketEntityName(name: string): string {
+  return `['${name}']`;
+}
+
+/**
+ * A control/management command is any statement that starts with a dot.
+ */
+export function isControlCommand(query: string): boolean {
+  return query.trimStart().startsWith('.');
+}
+
+/**
+ * Read-only control commands are the introspective `.show` family. Everything
+ * else that starts with a dot (e.g. `.set`, `.append`, `.ingest`, `.drop`,
+ * `.create`, `.alter`) can mutate data or schema.
+ */
+export function isReadOnlyControlCommand(query: string): boolean {
+  return /^\s*\.show\b/i.test(query);
+}
+
+/**
+ * Append an N+1 row limit to a query so the caller can detect whether more
+ * data is available than requested. The `take` is added on a NEW LINE so it
+ * doesn't merge into a trailing single-line comment (`// ...`), and is skipped
+ * for control commands (`.show ...`), which don't accept a piped `| take`.
+ * Kusto returns the top rows when the source is sorted, so ordering of sorted
+ * queries is preserved.
+ */
+export function appendRowLimit(query: string, limitPlusOne: number): string {
+  if (isControlCommand(query)) {
+    return query;
+  }
+  return `${query}\n| take ${limitPlusOne}`;
+}
+
+/**
+ * Enforce read-only mode. Plain KQL queries are always reads; `.show` commands
+ * are reads. Any other dot-command is a write/management command and is
+ * rejected unless writes are explicitly enabled.
+ */
+export function assertQueryAllowed(query: string, allowWrite: boolean): void {
+  if (
+    !allowWrite &&
+    isControlCommand(query) &&
+    !isReadOnlyControlCommand(query)
+  ) {
+    throw new KustoValidationError(
+      'Management/write commands are disabled: this server runs in read-only mode. ' +
+        'Only KQL queries and ".show" commands are permitted. ' +
+        'Set KUSTO_ALLOW_WRITE_OPERATIONS=true to enable write/management commands.',
+    );
+  }
+}

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -19,15 +19,3 @@ export function debugLog(message: string): void {
     process.stderr.write(`${message}\n`);
   }
 }
-
-/**
- * @deprecated Use criticalLog() or debugLog() instead
- * Safe logging function that won't interfere with MCP protocol
- *
- * @param message The message to log
- */
-export function safeLog(message: string): void {
-  if (process.env.DEBUG_SERVER === '1') {
-    process.stderr.write(`${message}\n`);
-  }
-}

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,0 +1,10 @@
+import { createRequire } from 'module';
+
+// Read the version from package.json at runtime so the MCP handshake always
+// reports the real published version. package.json sits one level above both
+// src/ (dev via ts-node) and dist/ (built), so '../../package.json' resolves
+// correctly from src/common/ and dist/common/ alike.
+const requireFromHere = createRequire(import.meta.url);
+const pkg = requireFromHere('../../package.json') as { version: string };
+
+export const VERSION: string = pkg.version;

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,23 @@ if (process.env.KUSTO_ENABLE_PROMPTS) {
   criticalLog('MCP prompts enabled by default');
 }
 
+// Determine read-only enforcement from environment variables. Writes are
+// allowed by default; set KUSTO_ALLOW_WRITE_OPERATIONS=false to run read-only.
+let allowWriteOperations = true;
+if (process.env.KUSTO_ALLOW_WRITE_OPERATIONS) {
+  const value = process.env.KUSTO_ALLOW_WRITE_OPERATIONS.toLowerCase();
+  allowWriteOperations = !(
+    value === 'false' ||
+    value === '0' ||
+    value === 'no'
+  );
+}
+criticalLog(
+  allowWriteOperations
+    ? 'Write/management commands enabled (default)'
+    : 'Running in READ-ONLY mode (write/management commands disabled)',
+);
+
 // Create the server configuration from environment variables
 const config: KustoConfig = {
   authMethod: authMethod,
@@ -135,6 +152,7 @@ const config: KustoConfig = {
       : undefined,
   enableQueryStatistics: enableQueryStatistics,
   enablePrompts: enablePrompts,
+  allowWriteOperations: allowWriteOperations,
 };
 
 // Log auto-connection configuration

--- a/src/operations/kusto/connection.ts
+++ b/src/operations/kusto/connection.ts
@@ -2,7 +2,11 @@ import { TokenCredential } from '@azure/identity';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
 import { Client, KustoConnectionStringBuilder } from 'azure-kusto-data';
 import { createTokenCredential } from '../../auth/token-credentials.js';
-import { KustoConnectionError, KustoQueryError } from '../../common/errors.js';
+import {
+  extractKustoErrorMessage,
+  KustoConnectionError,
+  KustoQueryError,
+} from '../../common/errors.js';
 import { criticalLog, debugLog } from '../../common/utils.js';
 import { KustoConfig } from '../../types/config.js';
 import { KustoQueryResult } from '../../types/kusto-interfaces.js';
@@ -86,18 +90,7 @@ export class KustoConnection {
           database: database,
         };
       } catch (error) {
-        let errorMessage =
-          error instanceof Error ? error.message : String(error);
-
-        // Extract detailed error message from Kusto response if available
-        if (error && typeof error === 'object' && 'response' in error) {
-          const response = (error as any).response;
-          if (response?.data?.error?.['@message']) {
-            errorMessage = response.data.error['@message'];
-          } else if (response?.data?.error?.message) {
-            errorMessage = response.data.error.message;
-          }
-        }
+        const errorMessage = extractKustoErrorMessage(error);
 
         criticalLog(`Failed to initialize connection: ${errorMessage}`);
 
@@ -124,7 +117,9 @@ export class KustoConnection {
     return tracer.startActiveSpan('executeQuery', async span => {
       try {
         span.setAttribute('database', database);
-        span.setAttribute('query', query);
+        // Avoid recording raw query text on spans exported to remote collectors
+        // (may contain sensitive values); record only its length.
+        span.setAttribute('query.length', query.length);
 
         if (!this.client) {
           throw new KustoConnectionError('Connection not initialized');
@@ -166,18 +161,7 @@ export class KustoConnection {
 
         return formattedResult;
       } catch (error) {
-        let errorMessage =
-          error instanceof Error ? error.message : String(error);
-
-        // Extract detailed error message from Kusto response if available
-        if (error && typeof error === 'object' && 'response' in error) {
-          const response = (error as any).response;
-          if (response?.data?.error?.['@message']) {
-            errorMessage = response.data.error['@message'];
-          } else if (response?.data?.error?.message) {
-            errorMessage = response.data.error.message;
-          }
-        }
+        const errorMessage = extractKustoErrorMessage(error);
 
         criticalLog(`Failed to execute query: ${errorMessage}`);
 

--- a/src/operations/kusto/queries.ts
+++ b/src/operations/kusto/queries.ts
@@ -1,5 +1,8 @@
 import { SpanStatusCode, trace } from '@opentelemetry/api';
-import { KustoQueryError } from '../../common/errors.js';
+import {
+  extractKustoErrorMessage,
+  KustoQueryError,
+} from '../../common/errors.js';
 import { criticalLog, debugLog } from '../../common/utils.js';
 import { KustoQueryResult } from '../../types/kusto-interfaces.js';
 import { KustoConfig } from '../../types/config.js';
@@ -215,7 +218,7 @@ export async function executeQuery(
 ): Promise<KustoQueryResult> {
   return tracer.startActiveSpan('executeQuery', async span => {
     try {
-      span.setAttribute('query', query);
+      span.setAttribute('query.length', query.length);
 
       debugLog(`Executing query: ${query}`);
 
@@ -234,17 +237,7 @@ export async function executeQuery(
 
       return result;
     } catch (error) {
-      let errorMessage = error instanceof Error ? error.message : String(error);
-
-      // Extract detailed error message from Kusto response if available
-      if (error && typeof error === 'object' && 'response' in error) {
-        const response = (error as any).response;
-        if (response?.data?.error?.['@message']) {
-          errorMessage = response.data.error['@message'];
-        } else if (response?.data?.error?.message) {
-          errorMessage = response.data.error.message;
-        }
-      }
+      const errorMessage = extractKustoErrorMessage(error);
 
       criticalLog(`Failed to execute query: ${errorMessage}`);
 
@@ -350,7 +343,7 @@ export async function executeQueryWithTransformation(
     'executeQueryWithTransformation',
     async span => {
       try {
-        span.setAttribute('query', query);
+        span.setAttribute('query.length', query.length);
 
         // Execute the raw query
         const rawResult = await executeQuery(connection, query);
@@ -361,18 +354,7 @@ export async function executeQueryWithTransformation(
         span.setStatus({ code: SpanStatusCode.OK });
         return transformedResult;
       } catch (error) {
-        let errorMessage =
-          error instanceof Error ? error.message : String(error);
-
-        // Extract detailed error message from Kusto response if available
-        if (error && typeof error === 'object' && 'response' in error) {
-          const response = (error as any).response;
-          if (response?.data?.error?.['@message']) {
-            errorMessage = response.data.error['@message'];
-          } else if (response?.data?.error?.message) {
-            errorMessage = response.data.error.message;
-          }
-        }
+        const errorMessage = extractKustoErrorMessage(error);
 
         criticalLog(`Failed to execute and transform query: ${errorMessage}`);
 
@@ -407,7 +389,7 @@ export async function executeManagementCommand(
 ): Promise<any> {
   return tracer.startActiveSpan('executeManagementCommand', async span => {
     try {
-      span.setAttribute('command', command);
+      span.setAttribute('command.length', command.length);
 
       debugLog(`Executing management command: ${command}`);
 
@@ -426,17 +408,7 @@ export async function executeManagementCommand(
 
       return result;
     } catch (error) {
-      let errorMessage = error instanceof Error ? error.message : String(error);
-
-      // Extract detailed error message from Kusto response if available
-      if (error && typeof error === 'object' && 'response' in error) {
-        const response = (error as any).response;
-        if (response?.data?.error?.['@message']) {
-          errorMessage = response.data.error['@message'];
-        } else if (response?.data?.error?.message) {
-          errorMessage = response.data.error.message;
-        }
-      }
+      const errorMessage = extractKustoErrorMessage(error);
 
       criticalLog(`Failed to execute management command: ${errorMessage}`);
 

--- a/src/operations/kusto/tables.ts
+++ b/src/operations/kusto/tables.ts
@@ -3,6 +3,10 @@ import {
   KustoQueryError,
   KustoResourceNotFoundError,
 } from '../../common/errors.js';
+import {
+  bracketEntityName,
+  validateEntityName,
+} from '../../common/kql-safety.js';
 import { criticalLog, debugLog } from '../../common/utils.js';
 import {
   KustoFunctionListItem,
@@ -121,10 +125,14 @@ export async function showTable(
         throw new KustoQueryError('Connection not initialized');
       }
 
-      // Execute the query to get the table schema using getschema
+      // Execute the query to get the table schema using getschema. The table
+      // name is validated and bracket-quoted to prevent KQL injection.
+      const safeTable = bracketEntityName(
+        validateEntityName(tableName, 'table'),
+      );
       const result = await connection.executeQuery(
         database,
-        `${tableName} | getschema`,
+        `${safeTable} | getschema`,
       );
 
       // Extract the table schema data from the Kusto response
@@ -315,10 +323,14 @@ export async function showFunction(
         throw new KustoQueryError('Connection not initialized');
       }
 
-      // Execute the query to get the function details
+      // Execute the query to get the function details. The function name is
+      // validated and bracket-quoted to prevent KQL injection.
+      const safeFunction = bracketEntityName(
+        validateEntityName(functionName, 'function'),
+      );
       const result = await connection.executeQuery(
         database,
-        `.show function ${functionName}`,
+        `.show function ${safeFunction}`,
       );
 
       // Extract the function details data from the Kusto response

--- a/src/operations/prompts/prompt-manager.ts
+++ b/src/operations/prompts/prompt-manager.ts
@@ -16,7 +16,7 @@ export class PromptManager {
   /**
    * Get list of available prompts with optional pagination
    */
-  listPrompts(cursor?: string): ListPromptsResult {
+  listPrompts(_cursor?: string): ListPromptsResult {
     // For now, we'll return all prompts without pagination
     // In the future, this could be enhanced with actual pagination logic
     const promptList = this.prompts.map(prompt => ({

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,12 +6,12 @@ import {
   GetPromptRequestSchema,
   ListToolsRequestSchema,
   McpError,
-  ListPromptsResult,
-  GetPromptResult,
 } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { formatKustoMcpError, isKustoMcpError } from './common/errors.js';
 import { criticalLog, debugLog } from './common/utils.js';
+import { appendRowLimit, assertQueryAllowed } from './common/kql-safety.js';
+import { VERSION } from './common/version.js';
 import {
   executeQuery,
   KustoConnection,
@@ -65,7 +65,7 @@ export function createKustoServer(config: KustoConfig): Server {
   const server = new Server(
     {
       name: 'kusto-mcp',
-      version: '1.0.0',
+      version: VERSION,
     },
     {
       capabilities: {
@@ -294,18 +294,28 @@ export function createKustoServer(config: KustoConfig): Server {
             );
           }
 
+          // Enforce read-only mode unless writes are explicitly enabled.
+          assertQueryAllowed(
+            args.query,
+            validatedConfig.allowWriteOperations ?? false,
+          );
+
           // Get user-requested limit and global response limit
           const requestedLimit = args.limit || 20;
           const globalCharLimit = validatedConfig.maxResponseLength || 12000;
           const minRows = validatedConfig.minRowsInResponse || 1;
 
-          // Execute query with generous limit initially (for dynamic reduction)
-          // Use a reasonable upper bound to avoid excessive data fetching
+          // Fetch one extra row (N+1) so we can detect whether more data is
+          // available than the requested limit. The `take` is appended on a new
+          // line so it doesn't merge into a trailing line comment, and is
+          // skipped for control commands (".show ..."), which don't accept a
+          // piped `| take`. Per Kusto semantics, when the query is sorted the
+          // top rows are returned, so ordering is preserved.
           const initialLimit = requestedLimit;
-          const modifiedQuery = `${args.query} | take ${initialLimit + 1}`;
+          const modifiedQuery = appendRowLimit(args.query, initialLimit + 1);
 
-          // Import the transformation functions here to avoid auto-formatter issues
-          const { executeQueryWithTransformation, transformQueryResult } =
+          // Import the transformation function here to avoid auto-formatter issues
+          const { transformQueryResult } =
             await import('./operations/kusto/index.js');
           const { limitResponseSize } =
             await import('./common/response-limiter.js');

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -68,6 +68,13 @@ export interface KustoConfig {
    * Enable MCP prompts support
    */
   enablePrompts?: boolean;
+
+  /**
+   * Allow write/management commands (any non-".show" dot-command such as
+   * .set, .append, .ingest, .drop). Enabled by default; set to false to run
+   * the server in read-only mode and reject these commands.
+   */
+  allowWriteOperations?: boolean;
 }
 
 /**
@@ -82,6 +89,7 @@ export const DEFAULT_CONFIG: Partial<KustoConfig> = {
   minRowsInResponse: 1, // Always return at least 1 row if data exists
   enableQueryStatistics: false, // Disabled by default for backward compatibility
   enablePrompts: true, // Enable prompts by default
+  allowWriteOperations: true, // Allow writes by default (set false for read-only)
 };
 
 /**

--- a/tests/unit/suites/function-operations.test.ts
+++ b/tests/unit/suites/function-operations.test.ts
@@ -10,7 +10,6 @@ import { showFunction } from '../../../src/operations/kusto/index.js';
 import { showFunctions } from '../../../src/operations/kusto/tables.js';
 import {
   emptyFunctionListResponse,
-  emptyFunctionNameError,
   functionDetailsResponse,
   functionListResponse,
   nonExistentFunctionError,
@@ -131,7 +130,7 @@ describe('Function Operations Unit Tests', () => {
       // Verify the query was called correctly
       expect(mockExecuteQuery).toHaveBeenCalledWith(
         'ContosoSales',
-        '.show function SalesWithParams',
+        ".show function ['SalesWithParams']",
       );
     });
 
@@ -146,23 +145,18 @@ describe('Function Operations Unit Tests', () => {
       // Verify the query was attempted
       expect(mockExecuteQuery).toHaveBeenCalledWith(
         'ContosoSales',
-        '.show function NonExistentFunction123',
+        ".show function ['NonExistentFunction123']",
       );
     });
 
-    test('should handle empty function name', async () => {
-      // Mock error response for empty function name
-      mockExecuteQuery.mockRejectedValue(emptyFunctionNameError);
-
+    test('should reject empty function name before querying', async () => {
+      // An empty/invalid name is rejected by validation and never reaches the
+      // Kusto client.
       await expect(showFunction(connection, '')).rejects.toThrow(
-        KustoQueryError,
+        'Invalid function name',
       );
 
-      // Verify the query was attempted with empty name
-      expect(mockExecuteQuery).toHaveBeenCalledWith(
-        'ContosoSales',
-        '.show function ',
-      );
+      expect(mockExecuteQuery).not.toHaveBeenCalled();
     });
 
     test('should return consistent function details for repeated calls', async () => {
@@ -228,8 +222,16 @@ describe('Function Operations Unit Tests', () => {
       // Verify the query was attempted
       expect(mockExecuteQuery).toHaveBeenCalledWith(
         'ContosoSales',
-        '.show function Function-With-Dashes',
+        ".show function ['Function-With-Dashes']",
       );
+    });
+
+    test('should reject KQL-injection attempts in function name', async () => {
+      await expect(
+        showFunction(connection, 'f); .drop table secrets //'),
+      ).rejects.toThrow('Invalid function name');
+
+      expect(mockExecuteQuery).not.toHaveBeenCalled();
     });
 
     test('should handle case-sensitive function names correctly', async () => {

--- a/tests/unit/suites/kql-safety.test.ts
+++ b/tests/unit/suites/kql-safety.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for KQL safety helpers: identifier validation/bracketing,
+ * read-only enforcement, and the N+1 row-limit builder.
+ */
+
+import { KustoValidationError } from '../../../src/common/errors.js';
+import {
+  appendRowLimit,
+  assertQueryAllowed,
+  bracketEntityName,
+  isControlCommand,
+  isReadOnlyControlCommand,
+  validateEntityName,
+} from '../../../src/common/kql-safety.js';
+
+describe('KQL Safety', () => {
+  describe('validateEntityName', () => {
+    test.each([
+      'SalesFact',
+      'Table-With-Dashes',
+      'Table.With.Dots',
+      'Has Spaces',
+      '_underscore',
+      'a1b2c3',
+    ])('accepts legal identifier %p', name => {
+      expect(validateEntityName(name)).toBe(name);
+    });
+
+    test('trims surrounding whitespace', () => {
+      expect(validateEntityName('  SalesFact  ')).toBe('SalesFact');
+    });
+
+    test.each([
+      '',
+      '   ',
+      "x'); .drop table y //",
+      'name | take 1',
+      'a; b',
+      'tbl)',
+      "['injected']",
+      'has\nnewline',
+      'col:type',
+    ])('rejects unsafe identifier %p', name => {
+      expect(() => validateEntityName(name, 'table')).toThrow(
+        KustoValidationError,
+      );
+      expect(() => validateEntityName(name, 'table')).toThrow(
+        /Invalid table name/,
+      );
+    });
+  });
+
+  describe('bracketEntityName', () => {
+    test('wraps a validated name in bracket-quote notation', () => {
+      expect(bracketEntityName('SalesFact')).toBe("['SalesFact']");
+      expect(bracketEntityName('Has Spaces')).toBe("['Has Spaces']");
+    });
+  });
+
+  describe('isControlCommand / isReadOnlyControlCommand', () => {
+    test('detects dot-prefixed control commands', () => {
+      expect(isControlCommand('.show tables')).toBe(true);
+      expect(isControlCommand('   .drop table X')).toBe(true);
+      expect(isControlCommand('SalesFact | take 5')).toBe(false);
+    });
+
+    test('only .show commands are read-only', () => {
+      expect(isReadOnlyControlCommand('.show tables')).toBe(true);
+      expect(isReadOnlyControlCommand('.SHOW database schema')).toBe(true);
+      expect(isReadOnlyControlCommand('.drop table X')).toBe(false);
+      expect(isReadOnlyControlCommand('.set-or-append T <| Y')).toBe(false);
+    });
+  });
+
+  describe('assertQueryAllowed (read-only enforcement)', () => {
+    test('allows plain KQL queries in read-only mode', () => {
+      expect(() => assertQueryAllowed('SalesFact | count', false)).not.toThrow();
+    });
+
+    test('allows .show commands in read-only mode', () => {
+      expect(() => assertQueryAllowed('.show tables', false)).not.toThrow();
+    });
+
+    test.each(['.drop table X', '.set-or-append T <| Y', '.ingest inline', '.create table Z'])(
+      'blocks write/management command %p in read-only mode',
+      cmd => {
+        expect(() => assertQueryAllowed(cmd, false)).toThrow(
+          KustoValidationError,
+        );
+      },
+    );
+
+    test('allows write commands when writes are enabled', () => {
+      expect(() => assertQueryAllowed('.drop table X', true)).not.toThrow();
+    });
+  });
+
+  describe('appendRowLimit', () => {
+    test('appends take on a new line for normal queries', () => {
+      expect(appendRowLimit('SalesFact', 21)).toBe('SalesFact\n| take 21');
+    });
+
+    test('new-line placement survives a trailing line comment', () => {
+      const result = appendRowLimit('SalesFact // newest first', 21);
+      // The take must be on its own line, not swallowed by the comment.
+      expect(result).toBe('SalesFact // newest first\n| take 21');
+      expect(result.split('\n')[1]).toBe('| take 21');
+    });
+
+    test('does not append take to control commands', () => {
+      expect(appendRowLimit('.show tables', 21)).toBe('.show tables');
+    });
+  });
+});

--- a/tests/unit/suites/table-operations.test.ts
+++ b/tests/unit/suites/table-operations.test.ts
@@ -1,7 +1,6 @@
 import { KustoConnection } from '../../../src/operations/kusto/connection.js';
 import { showTable, showTables } from '../../../src/operations/kusto/tables.js';
 import {
-  emptyTableNameError,
   nonExistentTableError,
   showTableSchemaProcessedResponse,
   showTablesProcessedResponse,
@@ -100,7 +99,7 @@ describe('Table Operations', () => {
     // Verify the executeQuery was called with correct parameters
     expect(mockConnection.executeQuery).toHaveBeenCalledWith(
       'ContosoSales',
-      'SalesFact | getschema',
+      "['SalesFact'] | getschema",
     );
   });
 
@@ -120,26 +119,19 @@ describe('Table Operations', () => {
     // Verify the executeQuery was called with correct parameters
     expect(mockConnection.executeQuery).toHaveBeenCalledWith(
       'ContosoSales',
-      'NonExistentTable123 | getschema',
+      "['NonExistentTable123'] | getschema",
     );
   });
 
-  test('should handle empty table name', async () => {
-    // Arrange: Mock the executeQuery to throw an error for empty table name
-    (mockConnection.executeQuery as jest.Mock).mockRejectedValue(
-      emptyTableNameError,
-    );
-
-    // Act & Assert: Expect the function to throw an error
+  test('should reject empty table name before querying', async () => {
+    // Act & Assert: An empty/invalid name is rejected by validation and never
+    // reaches the Kusto client.
     await expect(showTable(mockConnection, '')).rejects.toThrow(
-      'Query error: Failed to get table schema: Query error: Failed to execute query: Request failed with status code 400',
+      'Invalid table name',
     );
 
-    // Verify the executeQuery was called with correct parameters
-    expect(mockConnection.executeQuery).toHaveBeenCalledWith(
-      'ContosoSales',
-      ' | getschema',
-    );
+    // Verify the executeQuery was never called for an invalid identifier
+    expect(mockConnection.executeQuery).not.toHaveBeenCalled();
   });
 
   test('should validate table schema structure matches expected format', async () => {
@@ -221,8 +213,18 @@ describe('Table Operations', () => {
     // Verify the executeQuery was called with correct parameters
     expect(mockConnection.executeQuery).toHaveBeenCalledWith(
       'ContosoSales',
-      'Table-With-Dashes | getschema',
+      "['Table-With-Dashes'] | getschema",
     );
+  });
+
+  test('should reject KQL-injection attempts in table name', async () => {
+    // A name crafted to break out of the getschema command must be rejected by
+    // validation and never reach the Kusto client.
+    await expect(
+      showTable(mockConnection, 'x | extend p=1); .drop table secrets //'),
+    ).rejects.toThrow('Invalid table name');
+
+    expect(mockConnection.executeQuery).not.toHaveBeenCalled();
   });
 
   // Additional unit test specific validation


### PR DESCRIPTION
Maintenance pass after ~3 months of dependabot-only activity. Addresses correctness and security findings from a full repo audit. This is also the first `fix:`-prefixed commit since 1.10.1, so merging triggers a release that finally ships the accumulated dependency bumps.

## Security / correctness
- **KQL injection**: table/function names are now validated against the legal Kusto identifier charset and bracket-quoted (`['name']`) before interpolation in `show-table` / `show-function`.
- **Read-only mode**: new `KUSTO_ALLOW_WRITE_OPERATIONS` env var (default `true`, non-breaking). Set `false` to reject any non-`.show` management command.
- **`| take N+1` rewrite**: appended on a new line and skipped for control commands, so trailing-comment and `.show` queries are no longer corrupted. (Per Kusto docs, `take` preserves order on sorted input, so sorted queries were never actually affected.)
- **Telemetry leak**: raw query text removed from OpenTelemetry spans (length only).

## Tooling / hygiene
- **ESLint glob fix**: `eslint src` now lints all of `src/` instead of ~8/18 files (`src/**/*.ts` under `sh` silently skipped `src/operations/**` and top-level files). `no-explicit-any` downgraded to warnings (tracked tech-debt).
- **Server version**: handshake reports the real `package.json` version instead of hard-coded `1.0.0`.
- **Dependencies**: dropped unused `azure-kusto-ingest` and `axios`; `npm audit fix`. Prod-tree vulns: 18 (incl. 3 high) → 10 moderate (all upstream `uuid`, no fix available).
- Consolidated duplicated Kusto error-extraction; removed dead code (`safeLog`, unused imports); added `"license": "MIT"`.

## Tests
- New `kql-safety` unit suite (validation, read-only enforcement, take-limit) + injection/empty-name guards for table/function ops. Red→green verified by reverting fixes.
- **136 unit tests pass**; **59 e2e tests pass** against `help.kusto.windows.net`.

## Notes
- Behavior of `execute-query` is unchanged by default (writes still allowed); read-only is opt-in.