### PR TITLE
feat: anonymity-preserving connection/auth diagnostics + connection timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Kusto Configuration
 KUSTO_AUTH_METHOD=azure-identity    # Options: azure-identity, azure-cli
 KUSTO_QUERY_TIMEOUT=60000           # Timeout in milliseconds (default: 60000)
+KUSTO_CONNECTION_TIMEOUT=20000      # Connection init timeout in ms (default: 20000)
 KUSTO_RESPONSE_FORMAT=json          # Options: json, markdown (default: json)
 KUSTO_MARKDOWN_MAX_CELL_LENGTH=1000 # Maximum characters per table cell (default: 1000)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -10,6 +10,7 @@ Create a `.env` file based on the provided `.env.example`:
 # Kusto Configuration
 KUSTO_AUTH_METHOD=azure-cli  # Options: azure-identity, azure-cli
 KUSTO_QUERY_TIMEOUT=60000  # Timeout in milliseconds (default: 60000)
+KUSTO_CONNECTION_TIMEOUT=20000  # Connection init timeout in ms (default: 20000)
 KUSTO_RESPONSE_FORMAT=json  # Options: json, markdown (default: json)
 KUSTO_MARKDOWN_MAX_CELL_LENGTH=1000  # Maximum characters per table cell (default: 1000)
 
@@ -293,6 +294,17 @@ This is useful for:
 - Long-running analytical queries
 - Large dataset processing
 - Preventing resource exhaustion
+
+### Connection Timeout
+
+Connection initialization (token acquisition + a `print now()` validation
+round-trip) is bounded separately, so an unreachable cluster or a hung auth
+fails fast instead of inheriting the client library's multi-minute default:
+
+```bash
+# Bound connection setup (default: 20000ms = 20s)
+KUSTO_CONNECTION_TIMEOUT=20000
+```
 
 ## Performance Tuning
 

--- a/src/common/identity.ts
+++ b/src/common/identity.ts
@@ -26,6 +26,29 @@ const MSA_TENANT = '9188040d-6c67-4c5b-b112-36a304b66dad';
 
 let identityAttrs: Attributes = {};
 
+/**
+ * Lifecycle of identity capture for the current connection:
+ *   - pre_connect: no connection attempt yet (initial).
+ *   - unavailable: a token acquisition was attempted but no identity resolved
+ *     (auth failed, or the token had no id claims) — makes the "authenticated
+ *     but unidentifiable" cohort countable instead of a silent blank.
+ *   - captured: cohort hashes were derived from a token.
+ */
+type IdentityState = 'pre_connect' | 'captured' | 'unavailable';
+let identityState: IdentityState = 'pre_connect';
+
+// AADSTS codes for conditional-access / MFA-style failures → a stable stage.
+const CONDITIONAL_ACCESS_CODES = new Set([50076, 50079, 50005, 53003, 50158]);
+// Structured OAuth error identifiers (errorResponse.error) → failure stage.
+const OAUTH_ERROR_STAGE: Record<string, string> = {
+  interaction_required: 'interactive_required',
+  consent_required: 'consent_required',
+  invalid_client: 'invalid_client',
+  unauthorized_client: 'invalid_client',
+  invalid_grant: 'invalid_grant',
+  invalid_scope: 'invalid_scope',
+};
+
 /** One-way salted hash, truncated. */
 function hashId(value: string): string {
   return crypto
@@ -74,23 +97,79 @@ export function buildIdentityAttributes(
 
 /** Anonymous cohort attributes for the current connection. */
 export function getIdentityAttributes(): Attributes {
-  return identityAttrs;
+  return { ...identityAttrs, 'kustomcp.identity_state': identityState };
 }
 
 export function clearIdentity(): void {
   identityAttrs = {};
+  identityState = 'pre_connect';
+}
+
+/**
+ * Classify a token-acquisition failure into bounded, non-identifying cohort
+ * attributes. Reads ONLY structured fields — @azure/identity's
+ * `errorResponse.errorCodes` (numeric AADSTS codes) and `.error` (an OAuth error
+ * identifier) — plus the error class name. It never reads any message,
+ * errorDescription, correlationId, traceId, or timestamp, so nothing free-form
+ * or identifying can escape. Cardinality is bounded by the enum/code sets.
+ */
+function classifyAuthError(error: unknown): Attributes {
+  const attrs: Attributes = { 'kustomcp.auth.token_acquired': false };
+  const name = error instanceof Error ? error.name : '';
+
+  // ChainedTokenCredential aggregates each credential's failure; the first
+  // AuthenticationError carries the structured AAD response.
+  const inner =
+    name === 'AggregateAuthenticationError'
+      ? (error as { errors?: unknown[] }).errors?.[0]
+      : error;
+  const resp = (
+    inner as {
+      errorResponse?: { error?: string; errorCodes?: number[] };
+    } | null
+  )?.errorResponse;
+
+  if (resp) {
+    const code = Array.isArray(resp.errorCodes)
+      ? resp.errorCodes[0]
+      : undefined;
+    // A Microsoft-published error code (app/policy state), not tenant identity.
+    if (typeof code === 'number')
+      attrs['kustomcp.auth.aadsts'] = `AADSTS${code}`;
+    attrs['kustomcp.auth.failure_stage'] =
+      (typeof code === 'number' &&
+        CONDITIONAL_ACCESS_CODES.has(code) &&
+        'conditional_access') ||
+      (resp.error && OAUTH_ERROR_STAGE[resp.error]) ||
+      'token_acquire';
+    return attrs;
+  }
+
+  // Credential-unavailable (e.g. Azure CLI not installed / not logged in).
+  // Classified by CLASS only — we intentionally do NOT read its message, so
+  // the granularity is coarse rather than risk echoing environment specifics.
+  if (name === 'CredentialUnavailableError') {
+    attrs['kustomcp.auth.failure_stage'] = 'credential_unavailable';
+    return attrs;
+  }
+
+  attrs['kustomcp.auth.failure_stage'] = 'unknown';
+  return attrs;
 }
 
 /**
  * Acquire a token, decode its identity claims (tenant, object id, principal
  * type), and store the salted cohort hashes. Never throws — telemetry must not
- * break a connection.
+ * break a connection. On failure it records a bounded, non-identifying
+ * classification of WHY (see classifyAuthError) instead of a silent blank.
  */
 export async function captureIdentity(
   clusterUrl: string,
   getToken: (scope: string) => Promise<{ token: string } | null>,
 ): Promise<Attributes> {
   identityAttrs = {};
+  // A token acquisition is being attempted; downgraded to 'captured' on success.
+  identityState = 'unavailable';
   try {
     const origin = new URL(clusterUrl).origin;
     const tokenResponse = await getToken(`${origin}/.default`);
@@ -98,11 +177,15 @@ export async function captureIdentity(
       identityAttrs = buildIdentityAttributes(
         decodeJwtClaims(tokenResponse.token),
       );
+      identityState = 'captured';
       debugLog('Telemetry identity captured');
     }
   } catch (error) {
+    identityAttrs = classifyAuthError(error);
     debugLog(
-      `Telemetry identity capture skipped: ${error instanceof Error ? error.message : String(error)}`,
+      `Telemetry identity capture failed: stage=${String(
+        identityAttrs['kustomcp.auth.failure_stage'],
+      )}`,
     );
   }
   return identityAttrs;

--- a/src/common/machine-id.ts
+++ b/src/common/machine-id.ts
@@ -17,6 +17,10 @@ import { debugLog } from './utils.js';
  *   - Windows: %LOCALAPPDATA%\kusto-mcp\machine_id
  *   - other:   $XDG_DATA_HOME/kusto-mcp/machine_id  (default ~/.local/share/...)
  * Delete the file to reset the id.
+ *
+ * The file holds JSON: { machineId, firstSeen (date-floored), hasConnected }.
+ * A legacy file (a bare UUID string from older versions) is still read; its
+ * firstSeen is derived from the file's birthtime, floored to the day.
  */
 
 function machineIdDir(): string {
@@ -29,37 +33,102 @@ function machineIdDir(): string {
   return join(xdg, 'kusto-mcp');
 }
 
+function machineIdFile(): string {
+  return join(machineIdDir(), 'machine_id');
+}
+
 export interface MachineIdentity {
   machineId: string;
-  firstSeen: string; // ISO date of the install
+  firstSeen: string; // YYYY-MM-DD (date-floored — no ms-precision fingerprint)
+  hasConnected: boolean; // has this install ever completed a connection?
   isFirstRun: boolean;
 }
 
-export function loadOrCreateMachineId(): MachineIdentity {
-  const file = join(machineIdDir(), 'machine_id');
+interface StoredIdentity {
+  machineId: string;
+  firstSeen: string;
+  hasConnected: boolean;
+}
+
+/** Parse the store, tolerating both the JSON format and a legacy bare UUID. */
+function readStored(file: string): StoredIdentity | null {
+  let raw: string;
   try {
-    if (existsSync(file)) {
-      const machineId = readFileSync(file, 'utf8').trim();
-      if (machineId) {
-        let firstSeen = new Date().toISOString();
-        try {
-          firstSeen = statSync(file).birthtime.toISOString();
-        } catch {
-          /* birthtime unavailable on some filesystems */
-        }
-        return { machineId, firstSeen, isFirstRun: false };
-      }
-    }
+    raw = readFileSync(file, 'utf8').trim();
   } catch (error) {
     debugLog(`machine_id read failed: ${String(error)}`);
+    return null;
+  }
+  if (!raw) return null;
+
+  if (raw.startsWith('{')) {
+    try {
+      const obj = JSON.parse(raw) as Partial<StoredIdentity>;
+      if (obj.machineId) {
+        return {
+          machineId: obj.machineId,
+          firstSeen: obj.firstSeen || new Date().toISOString().slice(0, 10),
+          hasConnected: !!obj.hasConnected,
+        };
+      }
+    } catch {
+      /* fall through to treat as legacy/corrupt */
+    }
+    return null;
   }
 
-  const machineId = randomUUID();
+  // Legacy bare-UUID file: derive firstSeen from birthtime (date only).
+  let firstSeen = new Date().toISOString().slice(0, 10);
+  try {
+    firstSeen = statSync(file).birthtime.toISOString().slice(0, 10);
+  } catch {
+    /* birthtime unavailable on some filesystems */
+  }
+  return { machineId: raw, firstSeen, hasConnected: false };
+}
+
+function writeStored(file: string, value: StoredIdentity): void {
   try {
     mkdirSync(machineIdDir(), { recursive: true });
-    writeFileSync(file, `${machineId}\n`, { mode: 0o600 });
+    writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
   } catch (error) {
     debugLog(`machine_id write failed: ${String(error)}`);
   }
-  return { machineId, firstSeen: new Date().toISOString(), isFirstRun: true };
+}
+
+export function loadOrCreateMachineId(): MachineIdentity {
+  const file = machineIdFile();
+  if (existsSync(file)) {
+    const stored = readStored(file);
+    if (stored) {
+      return { ...stored, isFirstRun: false };
+    }
+  }
+
+  const created: StoredIdentity = {
+    machineId: randomUUID(),
+    firstSeen: new Date().toISOString().slice(0, 10),
+    hasConnected: false,
+  };
+  writeStored(file, created);
+  return { ...created, isFirstRun: true };
+}
+
+// Avoid re-touching the file more than once per process.
+let markedThisProcess = false;
+
+/**
+ * Record that this install has completed a connection at least once. Returns
+ * true only the FIRST time it flips (per install) — i.e. the install's very
+ * first successful connection. Best-effort; never throws.
+ */
+export function markConnected(): boolean {
+  if (markedThisProcess) return false;
+  markedThisProcess = true;
+  const file = machineIdFile();
+  const stored = readStored(file);
+  if (!stored) return false; // no id yet (shouldn't happen post-startup)
+  if (stored.hasConnected) return false;
+  writeStored(file, { ...stored, hasConnected: true });
+  return true;
 }

--- a/src/common/telemetry.ts
+++ b/src/common/telemetry.ts
@@ -321,6 +321,13 @@ export const queryDurationHistogram = lazyHistogram('kustomcp.query.duration', {
   unit: 'ms',
   description: 'Kusto query execution duration',
 });
+export const connectionDurationHistogram = lazyHistogram(
+  'kustomcp.connection.duration',
+  {
+    unit: 'ms',
+    description: 'Connection initialization duration',
+  },
+);
 export const queryRowsHistogram = lazyHistogram(
   'kustomcp.query.rows_returned',
   {

--- a/src/common/telemetry.ts
+++ b/src/common/telemetry.ts
@@ -197,16 +197,55 @@ export function emitLog(
 // Span helpers
 // ---------------------------------------------------------------------------
 
+// Marks an error object whose `exception` event has already been recorded on a
+// span. A Symbol keeps the mark invisible to Object.keys / JSON / for-in, so it
+// never leaks into exported telemetry — it lives only on the in-process error.
+const EXCEPTION_RECORDED = Symbol('kustomcp.exceptionRecorded');
+
 /**
  * Mark a span as failed WITHOUT leaking any message. Kusto error messages can
  * echo identifiers or query fragments, so we record only the error class name
  * (as `kustomcp.error.type`) — never the raw message or a stack that contains it.
+ *
+ * Idempotent per error object: the `exception` event is recorded once, on the
+ * first (innermost / originating) span to see the error. Outer spans that catch
+ * a re-wrapped copy still stamp `kustomcp.error.type` + ERROR status but skip
+ * the duplicate event, so one failure is no longer counted 2-3x across the
+ * nested wrapper spans. Re-wrapping layers must call `carryErrorRecording` so
+ * the mark survives the new error object.
  */
 export function recordSpanError(span: Span, error: unknown): void {
   const type = error instanceof Error && error.name ? error.name : 'Error';
   span.setAttribute('kustomcp.error.type', type);
-  span.recordException({ name: type });
+  const obj =
+    error && typeof error === 'object'
+      ? (error as Record<PropertyKey, unknown>)
+      : undefined;
+  if (!obj?.[EXCEPTION_RECORDED]) {
+    span.recordException({ name: type });
+    if (obj && Object.isExtensible(obj)) obj[EXCEPTION_RECORDED] = true;
+  }
   span.setStatus({ code: SpanStatusCode.ERROR });
+}
+
+/**
+ * Carry the "exception already recorded" mark from a caught error onto a new
+ * error that re-wraps it. Call immediately before re-throwing a freshly
+ * constructed error, so the enclosing span's `recordSpanError` recognises the
+ * failure as already recorded and doesn't emit a duplicate `exception` event.
+ */
+export function carryErrorRecording(from: unknown, to: unknown): void {
+  const f =
+    from && typeof from === 'object'
+      ? (from as Record<PropertyKey, unknown>)
+      : undefined;
+  const t =
+    to && typeof to === 'object'
+      ? (to as Record<PropertyKey, unknown>)
+      : undefined;
+  if (f?.[EXCEPTION_RECORDED] && t && Object.isExtensible(t)) {
+    t[EXCEPTION_RECORDED] = true;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,9 @@ const config: KustoConfig = {
   queryTimeout: process.env.KUSTO_QUERY_TIMEOUT
     ? parseInt(process.env.KUSTO_QUERY_TIMEOUT)
     : undefined,
+  connectionTimeout: process.env.KUSTO_CONNECTION_TIMEOUT
+    ? parseInt(process.env.KUSTO_CONNECTION_TIMEOUT)
+    : undefined,
   responseFormat: responseFormat,
   markdownMaxCellLength: process.env.KUSTO_MARKDOWN_MAX_CELL_LENGTH
     ? parseInt(process.env.KUSTO_MARKDOWN_MAX_CELL_LENGTH)

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,6 +165,7 @@ const resource = resourceFromAttributes({
   'host.arch': process.arch,
   'os.type': process.platform,
   'process.runtime.version': process.version,
+  'kustomcp.runtime.node_major': Number(process.versions.node.split('.')[0]),
   'kustomcp.config.auth_method': String(authMethod),
   'kustomcp.config.response_format': String(responseFormat),
   'kustomcp.config.allow_write': allowWriteOperations,
@@ -173,6 +174,7 @@ const resource = resourceFromAttributes({
   'kustomcp.config.autoconnect': autoConnect,
   'machine.id': machine.machineId,
   'kustomcp.machine.first_seen': machine.firstSeen,
+  'kustomcp.install.has_connected': machine.hasConnected,
 });
 
 // Telemetry is strictly best-effort — a failure to initialize it (e.g. a broken

--- a/src/operations/kusto/connection.ts
+++ b/src/operations/kusto/connection.ts
@@ -16,6 +16,7 @@ import {
   captureIdentity,
   getIdentityAttributes,
 } from '../../common/identity.js';
+import { markConnected } from '../../common/machine-id.js';
 import {
   SeverityNumber,
   carryErrorRecording,
@@ -151,6 +152,19 @@ function classifyCloud(
 }
 
 /**
+ * Coarse size bucket of a query, derived from its length only (the raw length
+ * already ships; this is strictly coarser). Lets us tell a heavy query from a
+ * systemic slowdown without any query text.
+ */
+function querySizeClass(length: number): 'xs' | 's' | 'm' | 'l' | 'xl' {
+  if (length < 128) return 'xs';
+  if (length < 512) return 's';
+  if (length < 2048) return 'm';
+  if (length < 8192) return 'l';
+  return 'xl';
+}
+
+/**
  * Class for managing connections to Kusto clusters
  */
 export class KustoConnection {
@@ -226,8 +240,13 @@ export class KustoConnection {
           // Best-effort; never throws. Done before validation so an authenticated
           // user that fails to connect is still counted. On failure this also
           // records a bounded classification of WHY (identity_state / auth.*).
+          const tokenStart = Date.now();
           await captureIdentity(clusterUrl, scope =>
             this.tokenCredential.getToken(scope),
+          );
+          span.setAttribute(
+            'kustomcp.connection.token_ms',
+            Date.now() - tokenStart,
           );
           for (const [k, v] of Object.entries(getIdentityAttributes())) {
             if (v !== undefined && v !== null) span.setAttribute(k, v);
@@ -259,7 +278,12 @@ export class KustoConnection {
 
           // Test basic connectivity and authentication with a universal query.
           // This works with regular Kusto clusters and ADX Proxy endpoints.
+          const connectStart = Date.now();
           await tempClient.execute(database, 'print now()', props);
+          span.setAttribute(
+            'kustomcp.connection.connect_ms',
+            Date.now() - connectStart,
+          );
           return tempClient;
         };
 
@@ -270,6 +294,8 @@ export class KustoConnection {
         this.database = database;
 
         debugLog('Connection initialized successfully');
+        // Onboarding funnel: true only on this install's first-ever success.
+        span.setAttribute('kustomcp.connection.first_success', markConnected());
         span.setAttribute('kustomcp.connection.outcome', 'success');
         span.setAttribute('kustomcp.connection.timed_out', false);
         span.setAttribute(
@@ -354,14 +380,23 @@ export class KustoConnection {
           : 'query';
         const startedAt = Date.now();
         span.setAttribute('kustomcp.operation', operation);
-        // Never record raw query text on exported spans; record only its length.
+        // Never record raw query text on exported spans; record only its length
+        // and a coarse size bucket.
         span.setAttribute('kustomcp.query.length', query.length);
+        span.setAttribute(
+          'kustomcp.query.size_class',
+          querySizeClass(query.length),
+        );
         // Stamp the same anonymous cohort hashes carried on the parent tool span,
         // so query outcomes/timeouts are sliceable by user/company without a
         // trace-join. No new information type — these already exist on the trace.
         for (const [k, v] of Object.entries(getIdentityAttributes())) {
           if (v !== undefined && v !== null) span.setAttribute(k, v);
         }
+
+        // Tracks whether OUR client-side timeout fired (vs a server timeout),
+        // without reading the error message.
+        let clientTimedOut = false;
 
         try {
           if (!this.client) {
@@ -380,6 +415,7 @@ export class KustoConnection {
 
           const rawResult = await new Promise((resolve, reject) => {
             timeoutHandle = setTimeout(() => {
+              clientTimedOut = true;
               reject(new KustoQueryError(`Query timed out after ${timeout}ms`));
             }, timeout);
 
@@ -420,6 +456,14 @@ export class KustoConnection {
           criticalLog(`Failed to execute query: ${errorMessage}`);
 
           span.setAttribute('kustomcp.outcome', outcome);
+          if (outcome === 'timeout') {
+            // Our wrapper fired (raise queryTimeout / heavy query) vs the server
+            // reporting its own timeout (cluster-side pressure).
+            span.setAttribute(
+              'kustomcp.query.timeout_kind',
+              clientTimedOut ? 'client' : 'server',
+            );
+          }
           recordSpanError(span, error);
           queriesCounter.add(1, {
             operation,

--- a/src/operations/kusto/connection.ts
+++ b/src/operations/kusto/connection.ts
@@ -20,6 +20,7 @@ import {
   SeverityNumber,
   carryErrorRecording,
   connectionAttemptsCounter,
+  connectionDurationHistogram,
   connectionFailuresCounter,
   emitLog,
   queriesCounter,
@@ -102,6 +103,54 @@ function classifyConnectionFailure(error: unknown): {
 }
 
 /**
+ * Map a failure category (+ whether our deadline fired) to a coarse connection
+ * outcome used as a metric label. Kept low-cardinality so it is cheap to slice.
+ */
+function connectionOutcome(
+  category: ReturnType<typeof classifyConnectionFailure>['category'],
+  timedOut: boolean,
+):
+  | 'timeout'
+  | 'auth_error'
+  | 'authz_denied'
+  | 'throttled'
+  | 'network_error'
+  | 'error' {
+  if (timedOut || category === 'timeout') return 'timeout';
+  if (category === 'auth') return 'auth_error';
+  if (category === 'authz') return 'authz_denied';
+  if (category === 'throttled') return 'throttled';
+  if (
+    category === 'dns_resolution' ||
+    category === 'connection_refused' ||
+    category === 'tls' ||
+    category === 'network'
+  )
+    return 'network_error';
+  return 'error';
+}
+
+/**
+ * Cloud class from the cluster host SUFFIX only. The org-specific subdomain is
+ * dropped before emit, so the result is one of four fixed, non-identifying
+ * values — never the cluster name.
+ */
+function classifyCloud(
+  clusterUrl: string,
+): 'public' | 'usgov' | 'china' | 'other' {
+  let host: string;
+  try {
+    host = new URL(clusterUrl).hostname.toLowerCase();
+  } catch {
+    return 'other';
+  }
+  if (host.endsWith('.kusto.windows.net')) return 'public';
+  if (host.endsWith('.kusto.usgovcloudapi.net')) return 'usgov';
+  if (host.endsWith('.kusto.chinacloudapi.cn')) return 'china';
+  return 'other';
+}
+
+/**
  * Class for managing connections to Kusto clusters
  */
 export class KustoConnection {
@@ -135,11 +184,22 @@ export class KustoConnection {
   ): Promise<{ success: boolean; cluster: string; database: string }> {
     return tracer.startActiveSpan('mcp.connection.init', async span => {
       span.setAttribute('kustomcp.connection.source', source);
+      span.setAttribute('kustomcp.cloud', classifyCloud(clusterUrl));
+      span.setAttribute(
+        'kustomcp.proxy_configured',
+        !!(
+          process.env.HTTPS_PROXY ||
+          process.env.https_proxy ||
+          process.env.HTTP_PROXY ||
+          process.env.http_proxy
+        ),
+      );
       connectionAttemptsCounter.add(1, { source });
       // Bound the whole init (token acquisition + validation round-trip). Without
       // it, the client's HTTP default is 270s (see azure-kusto-data
       // QUERY_TIMEOUT_IN_MILLISECS), so a bad URL or hung auth stalls for minutes.
       const connectTimeout = this.config.connectionTimeout ?? 20000;
+      const startedAt = Date.now();
       let timedOut = false;
       let deadlineTimer: NodeJS.Timeout | undefined;
       try {
@@ -210,6 +270,16 @@ export class KustoConnection {
         this.database = database;
 
         debugLog('Connection initialized successfully');
+        span.setAttribute('kustomcp.connection.outcome', 'success');
+        span.setAttribute('kustomcp.connection.timed_out', false);
+        span.setAttribute(
+          'kustomcp.connection.duration_ms',
+          Date.now() - startedAt,
+        );
+        connectionDurationHistogram.record(Date.now() - startedAt, {
+          source,
+          outcome: 'success',
+        });
         span.setStatus({ code: SpanStatusCode.OK });
         emitLog(SeverityNumber.INFO, 'INFO', 'Connection established', {
           'kustomcp.connection.source': source,
@@ -229,7 +299,14 @@ export class KustoConnection {
         // A fired deadline is definitively a timeout, regardless of the wrapped
         // error's shape.
         const category = timedOut ? 'timeout' : classified.category;
+        const outcome = connectionOutcome(classified.category, timedOut);
         span.setAttribute('kustomcp.connection.failure_category', category);
+        span.setAttribute('kustomcp.connection.outcome', outcome);
+        span.setAttribute('kustomcp.connection.timed_out', timedOut);
+        span.setAttribute(
+          'kustomcp.connection.duration_ms',
+          Date.now() - startedAt,
+        );
         if (classified.httpStatus !== undefined) {
           span.setAttribute('kustomcp.http.status_code', classified.httpStatus);
         }
@@ -237,6 +314,10 @@ export class KustoConnection {
           source,
           error_type: error instanceof Error ? error.name : 'unknown',
           failure_category: category,
+        });
+        connectionDurationHistogram.record(Date.now() - startedAt, {
+          source,
+          outcome,
         });
         recordSpanError(span, error);
         emitLog(SeverityNumber.ERROR, 'ERROR', 'Connection failed', {
@@ -275,6 +356,12 @@ export class KustoConnection {
         span.setAttribute('kustomcp.operation', operation);
         // Never record raw query text on exported spans; record only its length.
         span.setAttribute('kustomcp.query.length', query.length);
+        // Stamp the same anonymous cohort hashes carried on the parent tool span,
+        // so query outcomes/timeouts are sliceable by user/company without a
+        // trace-join. No new information type — these already exist on the trace.
+        for (const [k, v] of Object.entries(getIdentityAttributes())) {
+          if (v !== undefined && v !== null) span.setAttribute(k, v);
+        }
 
         try {
           if (!this.client) {

--- a/src/operations/kusto/connection.ts
+++ b/src/operations/kusto/connection.ts
@@ -72,10 +72,14 @@ function classifyConnectionFailure(error: unknown): {
     name?: string;
     code?: string;
     response?: { status?: number };
+    cause?: { code?: string };
   };
   if (e?.name === 'KustoAuthenticationError') return { category: 'auth' };
   if (e?.name === 'ThrottlingError')
     return { category: 'throttled', httpStatus: 429 };
+  // HTTP status is the most reliable signal for server-side failures. axios may
+  // rewrite the top-level code (e.g. ERR_BAD_REQUEST/ERR_BAD_RESPONSE) while the
+  // status still sits on error.response.
   const status = e?.response?.status;
   if (typeof status === 'number') {
     if (status === 401 || status === 403)
@@ -84,22 +88,28 @@ function classifyConnectionFailure(error: unknown): {
     if (status >= 500) return { category: 'http_5xx', httpStatus: status };
     if (status >= 400) return { category: 'http_4xx', httpStatus: status };
   }
-  switch (e?.code) {
-    case 'ENOTFOUND':
-    case 'EAI_AGAIN':
-      return { category: 'dns_resolution' };
-    case 'ECONNREFUSED':
-      return { category: 'connection_refused' };
-    case 'ETIMEDOUT':
-    case 'ECONNABORTED':
-      return { category: 'timeout' };
-    case 'ERR_NETWORK':
-      return { category: 'network' };
+  // Network-level failures: axios frequently nests the original OS error under
+  // `.cause`, so match the top-level code AND the cause's code.
+  const codes = [e?.code, e?.cause?.code].filter(
+    (c): c is string => typeof c === 'string',
+  );
+  for (const code of codes) {
+    switch (code) {
+      case 'ENOTFOUND':
+      case 'EAI_AGAIN':
+        return { category: 'dns_resolution' };
+      case 'ECONNREFUSED':
+        return { category: 'connection_refused' };
+      case 'ETIMEDOUT':
+      case 'ECONNABORTED':
+        return { category: 'timeout' };
+    }
+    // Node TLS error CODES (e.g. CERT_HAS_EXPIRED,
+    // UNABLE_TO_VERIFY_LEAF_SIGNATURE) — the code, never the message.
+    if (/CERT|_SSL|_SIGN|TLS/i.test(code)) return { category: 'tls' };
   }
-  // Node TLS error CODES (e.g. CERT_HAS_EXPIRED, UNABLE_TO_VERIFY_LEAF_SIGNATURE,
-  // DEPTH_ZERO_SELF_SIGNED_CERT) — the code, never the message.
-  if (e?.code && /CERT|_SSL|_SIGN|TLS/i.test(e.code))
-    return { category: 'tls' };
+  // axios's generic network error, when no more specific code surfaced.
+  if (codes.includes('ERR_NETWORK')) return { category: 'network' };
   return { category: 'unknown' };
 }
 
@@ -294,15 +304,15 @@ export class KustoConnection {
         this.database = database;
 
         debugLog('Connection initialized successfully');
-        // Onboarding funnel: true only on this install's first-ever success.
-        span.setAttribute('kustomcp.connection.first_success', markConnected());
+        // Record duration BEFORE markConnected so its one-time sync I/O (first
+        // success only) isn't folded into the reported connection duration.
+        const elapsedMs = Date.now() - startedAt;
         span.setAttribute('kustomcp.connection.outcome', 'success');
         span.setAttribute('kustomcp.connection.timed_out', false);
-        span.setAttribute(
-          'kustomcp.connection.duration_ms',
-          Date.now() - startedAt,
-        );
-        connectionDurationHistogram.record(Date.now() - startedAt, {
+        span.setAttribute('kustomcp.connection.duration_ms', elapsedMs);
+        // Onboarding funnel: true only on this install's first-ever success.
+        span.setAttribute('kustomcp.connection.first_success', markConnected());
+        connectionDurationHistogram.record(elapsedMs, {
           source,
           outcome: 'success',
         });
@@ -321,11 +331,24 @@ export class KustoConnection {
 
         criticalLog(`Failed to initialize connection: ${errorMessage}`);
 
+        // Debug-only (stderr, never telemetry): the raw fields the classifier
+        // keys on, so the failure_category enum can be validated against real
+        // azure-kusto-data/axios error shapes post-deploy.
+        const rawErr = error as {
+          name?: string;
+          code?: string;
+          cause?: { code?: string };
+          response?: { status?: number };
+        };
+        debugLog(
+          `connection failure shape: name=${rawErr?.name} code=${rawErr?.code} cause=${rawErr?.cause?.code} status=${rawErr?.response?.status}`,
+        );
+
         const classified = classifyConnectionFailure(error);
         // A fired deadline is definitively a timeout, regardless of the wrapped
         // error's shape.
         const category = timedOut ? 'timeout' : classified.category;
-        const outcome = connectionOutcome(classified.category, timedOut);
+        const outcome = connectionOutcome(category, timedOut);
         span.setAttribute('kustomcp.connection.failure_category', category);
         span.setAttribute('kustomcp.connection.outcome', outcome);
         span.setAttribute('kustomcp.connection.timed_out', timedOut);

--- a/src/operations/kusto/connection.ts
+++ b/src/operations/kusto/connection.ts
@@ -8,9 +8,13 @@ import {
   KustoQueryError,
 } from '../../common/errors.js';
 import { criticalLog, debugLog } from '../../common/utils.js';
-import { captureIdentity } from '../../common/identity.js';
+import {
+  captureIdentity,
+  getIdentityAttributes,
+} from '../../common/identity.js';
 import {
   SeverityNumber,
+  carryErrorRecording,
   connectionAttemptsCounter,
   connectionFailuresCounter,
   emitLog,
@@ -33,6 +37,64 @@ function classifyQueryOutcome(
   if (m.includes('throttl') || m.includes('e_too_many') || m.includes('429'))
     return 'throttled';
   return 'error';
+}
+
+/**
+ * Map a connection failure to a bounded, non-identifying category (+ the HTTP
+ * status when present). Reads only the error class name, the network `code`
+ * (ECONNREFUSED / ENOTFOUND / TLS cert codes …) and the numeric HTTP status —
+ * never the error message, which could echo a cluster/db name or identifier.
+ * The returned category is a closed enum safe to use as a span attribute and a
+ * metric label.
+ */
+function classifyConnectionFailure(error: unknown): {
+  category:
+    | 'dns_resolution'
+    | 'connection_refused'
+    | 'tls'
+    | 'timeout'
+    | 'network'
+    | 'http_4xx'
+    | 'http_5xx'
+    | 'authz'
+    | 'auth'
+    | 'throttled'
+    | 'unknown';
+  httpStatus?: number;
+} {
+  const e = error as {
+    name?: string;
+    code?: string;
+    response?: { status?: number };
+  };
+  if (e?.name === 'KustoAuthenticationError') return { category: 'auth' };
+  if (e?.name === 'ThrottlingError')
+    return { category: 'throttled', httpStatus: 429 };
+  const status = e?.response?.status;
+  if (typeof status === 'number') {
+    if (status === 401 || status === 403)
+      return { category: 'authz', httpStatus: status };
+    if (status === 429) return { category: 'throttled', httpStatus: status };
+    if (status >= 500) return { category: 'http_5xx', httpStatus: status };
+    if (status >= 400) return { category: 'http_4xx', httpStatus: status };
+  }
+  switch (e?.code) {
+    case 'ENOTFOUND':
+    case 'EAI_AGAIN':
+      return { category: 'dns_resolution' };
+    case 'ECONNREFUSED':
+      return { category: 'connection_refused' };
+    case 'ETIMEDOUT':
+    case 'ECONNABORTED':
+      return { category: 'timeout' };
+    case 'ERR_NETWORK':
+      return { category: 'network' };
+  }
+  // Node TLS error CODES (e.g. CERT_HAS_EXPIRED, UNABLE_TO_VERIFY_LEAF_SIGNATURE,
+  // DEPTH_ZERO_SELF_SIGNED_CERT) — the code, never the message.
+  if (e?.code && /CERT|_SSL|_SIGN|TLS/i.test(e.code))
+    return { category: 'tls' };
+  return { category: 'unknown' };
 }
 
 /**
@@ -68,6 +130,7 @@ export class KustoConnection {
     source: 'auto' | 'manual' = 'manual',
   ): Promise<{ success: boolean; cluster: string; database: string }> {
     return tracer.startActiveSpan('mcp.connection.init', async span => {
+      span.setAttribute('kustomcp.connection.source', source);
       connectionAttemptsCounter.add(1, { source });
       try {
         debugLog(
@@ -76,11 +139,12 @@ export class KustoConnection {
 
         // Capture anonymous cohort hashes (company/user) from the access token.
         // Best-effort; never throws. Done before validation so an authenticated
-        // user that fails to connect is still counted.
-        const identity = await captureIdentity(clusterUrl, scope =>
+        // user that fails to connect is still counted. On failure this also
+        // records a bounded classification of WHY (identity_state / auth.*).
+        await captureIdentity(clusterUrl, scope =>
           this.tokenCredential.getToken(scope),
         );
-        for (const [k, v] of Object.entries(identity)) {
+        for (const [k, v] of Object.entries(getIdentityAttributes())) {
           if (v !== undefined && v !== null) span.setAttribute(k, v);
         }
 
@@ -128,16 +192,27 @@ export class KustoConnection {
 
         criticalLog(`Failed to initialize connection: ${errorMessage}`);
 
+        const { category, httpStatus } = classifyConnectionFailure(error);
+        span.setAttribute('kustomcp.connection.failure_category', category);
+        if (httpStatus !== undefined) {
+          span.setAttribute('kustomcp.http.status_code', httpStatus);
+        }
         connectionFailuresCounter.add(1, {
+          source,
           error_type: error instanceof Error ? error.name : 'unknown',
+          failure_category: category,
         });
         recordSpanError(span, error);
         emitLog(SeverityNumber.ERROR, 'ERROR', 'Connection failed', {
+          'kustomcp.connection.source': source,
+          'kustomcp.connection.failure_category': category,
           'kustomcp.error.type':
             error instanceof Error ? error.name : 'unknown',
         });
 
-        throw new KustoConnectionError(errorMessage);
+        const wrapped = new KustoConnectionError(errorMessage);
+        carryErrorRecording(error, wrapped);
+        throw wrapped;
       } finally {
         span.end();
       }
@@ -234,6 +309,7 @@ export class KustoConnection {
           // Don't wrap as KustoQueryError here since queries.ts will handle it
           // Just rethrow with the detailed error message
           const customError = new Error(errorMessage);
+          carryErrorRecording(error, customError);
           throw customError;
         } finally {
           span.end();

--- a/src/operations/kusto/connection.ts
+++ b/src/operations/kusto/connection.ts
@@ -1,6 +1,10 @@
 import { TokenCredential } from '@azure/identity';
 import { SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
-import { Client, KustoConnectionStringBuilder } from 'azure-kusto-data';
+import {
+  Client,
+  ClientRequestProperties,
+  KustoConnectionStringBuilder,
+} from 'azure-kusto-data';
 import { createTokenCredential } from '../../auth/token-credentials.js';
 import {
   extractKustoErrorMessage,
@@ -132,45 +136,74 @@ export class KustoConnection {
     return tracer.startActiveSpan('mcp.connection.init', async span => {
       span.setAttribute('kustomcp.connection.source', source);
       connectionAttemptsCounter.add(1, { source });
+      // Bound the whole init (token acquisition + validation round-trip). Without
+      // it, the client's HTTP default is 270s (see azure-kusto-data
+      // QUERY_TIMEOUT_IN_MILLISECS), so a bad URL or hung auth stalls for minutes.
+      const connectTimeout = this.config.connectionTimeout ?? 20000;
+      let timedOut = false;
+      let deadlineTimer: NodeJS.Timeout | undefined;
       try {
         debugLog(
           `Initializing connection to ${clusterUrl}, database: ${database}`,
         );
 
-        // Capture anonymous cohort hashes (company/user) from the access token.
-        // Best-effort; never throws. Done before validation so an authenticated
-        // user that fails to connect is still counted. On failure this also
-        // records a bounded classification of WHY (identity_state / auth.*).
-        await captureIdentity(clusterUrl, scope =>
-          this.tokenCredential.getToken(scope),
-        );
-        for (const [k, v] of Object.entries(getIdentityAttributes())) {
-          if (v !== undefined && v !== null) span.setAttribute(k, v);
-        }
+        const deadline = new Promise<never>((_, reject) => {
+          deadlineTimer = setTimeout(() => {
+            timedOut = true;
+            reject(
+              new KustoConnectionError(
+                `Connection timed out after ${connectTimeout}ms`,
+              ),
+            );
+          }, connectTimeout);
+          // Don't keep the event loop alive solely for this timer.
+          deadlineTimer.unref?.();
+        });
 
-        // Create a connection string with the configured authentication method
-        let connectionString;
-
-        if (this.config.authMethod === 'azure-cli') {
-          debugLog('Using Azure CLI authentication for connection');
-          connectionString =
-            KustoConnectionStringBuilder.withAzLoginIdentity(clusterUrl);
-        } else {
-          debugLog(
-            'Using Azure Identity (DefaultAzureCredential) for connection',
+        // The connect critical section, raced against the deadline.
+        const connect = async (): Promise<Client> => {
+          // Capture anonymous cohort hashes (company/user) from the access token.
+          // Best-effort; never throws. Done before validation so an authenticated
+          // user that fails to connect is still counted. On failure this also
+          // records a bounded classification of WHY (identity_state / auth.*).
+          await captureIdentity(clusterUrl, scope =>
+            this.tokenCredential.getToken(scope),
           );
-          connectionString = KustoConnectionStringBuilder.withTokenCredential(
-            clusterUrl,
-            this.tokenCredential,
-          );
-        }
+          for (const [k, v] of Object.entries(getIdentityAttributes())) {
+            if (v !== undefined && v !== null) span.setAttribute(k, v);
+          }
 
-        // Create a temporary client for validation, don't set instance variables yet
-        const tempClient = new Client(connectionString);
+          // Create a connection string with the configured authentication method
+          let connectionString;
 
-        // Test basic connectivity and authentication with a universal query
-        // This works with regular Kusto clusters and ADX Proxy endpoints
-        await tempClient.execute(database, 'print now()');
+          if (this.config.authMethod === 'azure-cli') {
+            debugLog('Using Azure CLI authentication for connection');
+            connectionString =
+              KustoConnectionStringBuilder.withAzLoginIdentity(clusterUrl);
+          } else {
+            debugLog(
+              'Using Azure Identity (DefaultAzureCredential) for connection',
+            );
+            connectionString = KustoConnectionStringBuilder.withTokenCredential(
+              clusterUrl,
+              this.tokenCredential,
+            );
+          }
+
+          // Create a temporary client for validation, don't set instance variables yet
+          const tempClient = new Client(connectionString);
+
+          // Bound the HTTP round-trip itself (library default is 270s).
+          const props = new ClientRequestProperties();
+          props.setClientTimeout(connectTimeout);
+
+          // Test basic connectivity and authentication with a universal query.
+          // This works with regular Kusto clusters and ADX Proxy endpoints.
+          await tempClient.execute(database, 'print now()', props);
+          return tempClient;
+        };
+
+        const tempClient = await Promise.race([connect(), deadline]);
 
         // Only set the instance variables after successful validation
         this.client = tempClient;
@@ -192,10 +225,13 @@ export class KustoConnection {
 
         criticalLog(`Failed to initialize connection: ${errorMessage}`);
 
-        const { category, httpStatus } = classifyConnectionFailure(error);
+        const classified = classifyConnectionFailure(error);
+        // A fired deadline is definitively a timeout, regardless of the wrapped
+        // error's shape.
+        const category = timedOut ? 'timeout' : classified.category;
         span.setAttribute('kustomcp.connection.failure_category', category);
-        if (httpStatus !== undefined) {
-          span.setAttribute('kustomcp.http.status_code', httpStatus);
+        if (classified.httpStatus !== undefined) {
+          span.setAttribute('kustomcp.http.status_code', classified.httpStatus);
         }
         connectionFailuresCounter.add(1, {
           source,
@@ -214,6 +250,7 @@ export class KustoConnection {
         carryErrorRecording(error, wrapped);
         throw wrapped;
       } finally {
+        if (deadlineTimer) clearTimeout(deadlineTimer);
         span.end();
       }
     });

--- a/src/operations/kusto/queries.ts
+++ b/src/operations/kusto/queries.ts
@@ -4,7 +4,10 @@ import {
   KustoQueryError,
 } from '../../common/errors.js';
 import { criticalLog, debugLog } from '../../common/utils.js';
-import { recordSpanError } from '../../common/telemetry.js';
+import {
+  carryErrorRecording,
+  recordSpanError,
+} from '../../common/telemetry.js';
 import { KustoQueryResult } from '../../types/kusto-interfaces.js';
 import { KustoConfig } from '../../types/config.js';
 import { KustoConnection } from './connection.js';
@@ -241,7 +244,9 @@ export async function executeQuery(
 
       recordSpanError(span, error);
 
-      throw new KustoQueryError(errorMessage);
+      const wrapped = new KustoQueryError(errorMessage);
+      carryErrorRecording(error, wrapped);
+      throw wrapped;
     } finally {
       span.end();
     }
@@ -358,7 +363,9 @@ export async function executeQueryWithTransformation(
           throw error;
         }
 
-        throw new KustoQueryError(errorMessage);
+        const wrapped = new KustoQueryError(errorMessage);
+        carryErrorRecording(error, wrapped);
+        throw wrapped;
       } finally {
         span.end();
       }
@@ -401,7 +408,9 @@ export async function executeManagementCommand(
 
       recordSpanError(span, error);
 
-      throw new KustoQueryError(errorMessage);
+      const wrapped = new KustoQueryError(errorMessage);
+      carryErrorRecording(error, wrapped);
+      throw wrapped;
     } finally {
       span.end();
     }

--- a/src/operations/kusto/tables.ts
+++ b/src/operations/kusto/tables.ts
@@ -8,7 +8,10 @@ import {
   validateEntityName,
 } from '../../common/kql-safety.js';
 import { criticalLog, debugLog } from '../../common/utils.js';
-import { recordSpanError } from '../../common/telemetry.js';
+import {
+  carryErrorRecording,
+  recordSpanError,
+} from '../../common/telemetry.js';
 import {
   KustoFunctionListItem,
   KustoFunctionSchema,
@@ -90,7 +93,11 @@ export async function showTables(
 
       recordSpanError(span, error);
 
-      throw new KustoQueryError(`Failed to list tables: ${errorMessage}`);
+      const wrapped = new KustoQueryError(
+        `Failed to list tables: ${errorMessage}`,
+      );
+      carryErrorRecording(error, wrapped);
+      throw wrapped;
     } finally {
       span.end();
     }
@@ -193,7 +200,11 @@ export async function showTable(
         throw error;
       }
 
-      throw new KustoQueryError(`Failed to get table schema: ${errorMessage}`);
+      const wrapped = new KustoQueryError(
+        `Failed to get table schema: ${errorMessage}`,
+      );
+      carryErrorRecording(error, wrapped);
+      throw wrapped;
     } finally {
       span.end();
     }
@@ -280,7 +291,11 @@ export async function showFunctions(
 
       recordSpanError(span, error);
 
-      throw new KustoQueryError(`Failed to list functions: ${errorMessage}`);
+      const wrapped = new KustoQueryError(
+        `Failed to list functions: ${errorMessage}`,
+      );
+      carryErrorRecording(error, wrapped);
+      throw wrapped;
     } finally {
       span.end();
     }
@@ -388,9 +403,11 @@ export async function showFunction(
         throw error;
       }
 
-      throw new KustoQueryError(
+      const wrapped = new KustoQueryError(
         `Failed to get function details: ${errorMessage}`,
       );
+      carryErrorRecording(error, wrapped);
+      throw wrapped;
     } finally {
       span.end();
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -404,7 +404,9 @@ export function createKustoServer(config: KustoConfig): Server {
                 'kustomcp.write_allowed',
                 validatedConfig.allowWriteOperations ?? false,
               );
-              queryRowsHistogram.record(availableData.length);
+              queryRowsHistogram.record(availableData.length, {
+                tool: toolName,
+              });
 
               // Create base response structure with all available data
               const baseResponse = {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -29,6 +29,14 @@ export interface KustoConfig {
   queryTimeout?: number;
 
   /**
+   * Timeout for connection initialization (token acquisition + the `print now()`
+   * validation round-trip) in milliseconds. Without this the underlying client
+   * falls back to the library's 270s query default, so a bad cluster URL or a
+   * hung auth can leave the server stuck for minutes.
+   */
+  connectionTimeout?: number;
+
+  /**
    * The response format for query results
    */
   responseFormat?: ResponseFormat;
@@ -83,6 +91,7 @@ export interface KustoConfig {
 export const DEFAULT_CONFIG: Partial<KustoConfig> = {
   authMethod: AuthenticationMethod.AzureIdentity,
   queryTimeout: 60000, // 1 minute
+  connectionTimeout: 20000, // 20s — connection setup should be fast; bound the tail
   responseFormat: ResponseFormat.Json, // Default to JSON for backward compatibility
   markdownMaxCellLength: 1000, // Default to 1000 characters per cell
   maxResponseLength: 12000, // 12K characters - conservative for context windows

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -83,11 +83,28 @@ jest.mock('azure-kusto-data', () => {
     }
   }
 
+  class MockClientRequestProperties {
+    private clientTimeout?: number;
+    setClientTimeout(timeoutMillis: number) {
+      this.clientTimeout = timeoutMillis;
+    }
+    getClientTimeout() {
+      return this.clientTimeout;
+    }
+    setOption() {
+      /* no-op for tests */
+    }
+    toJSON() {
+      return {};
+    }
+  }
+
   return {
     Client: MockClient,
     KustoConnectionStringBuilder: MockKustoConnectionStringBuilder,
     KustoResultTable: MockKustoResultTable,
     KustoResultColumn: MockKustoResultColumn,
+    ClientRequestProperties: MockClientRequestProperties,
   };
 });
 

--- a/tests/unit/suites/connection-timeout.test.ts
+++ b/tests/unit/suites/connection-timeout.test.ts
@@ -1,0 +1,87 @@
+/**
+ * I5 — connection-init timeout. Without a bound, a hung auth or unreachable
+ * cluster inherits azure-kusto-data's 270s query default (verified in
+ * client.js: QUERY_TIMEOUT_IN_MILLISECS = 4m30s). initialize() now races the
+ * whole critical section against `connectionTimeout`, so it fails fast and the
+ * failure is classified as a timeout.
+ */
+
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+
+jest.mock('azure-kusto-data', () => ({
+  Client: jest.fn(),
+  KustoConnectionStringBuilder: {
+    withAzLoginIdentity: jest.fn(u => `cs-${u}`),
+    withTokenCredential: jest.fn(u => `cs-${u}`),
+  },
+  ClientRequestProperties: class {
+    setClientTimeout() {
+      /* no-op for tests */
+    }
+  },
+}));
+
+jest.mock('../../../src/auth/token-credentials.js', () => ({
+  createTokenCredential: jest.fn(() => ({
+    getToken: jest.fn().mockResolvedValue({
+      token: 'mock-token',
+      expiresOnTimestamp: Date.now() + 3600000,
+    }),
+  })),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import { KustoConnection } from '../../../src/operations/kusto/connection.js';
+import {
+  AuthenticationMethod,
+  KustoConfig,
+} from '../../../src/types/config.js';
+
+const exporter = new InMemorySpanExporter();
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+});
+
+describe('connection init is bounded by connectionTimeout (I5)', () => {
+  beforeAll(() => {
+    provider.register();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    exporter.reset();
+  });
+
+  test('a hung init rejects at connectionTimeout and classifies failure_category=timeout', async () => {
+    const { Client } = require('azure-kusto-data');
+    // execute never resolves → the deadline must fire.
+    const mockExecute = jest.fn(() => new Promise(() => {}));
+    Client.mockImplementation(() => ({ execute: mockExecute }));
+
+    const config: KustoConfig = {
+      authMethod: AuthenticationMethod.AzureCli,
+      connectionTimeout: 50,
+    };
+    const connection = new KustoConnection(config);
+
+    const start = Date.now();
+    await expect(
+      connection.initialize('https://help.kusto.windows.net', 'Samples'),
+    ).rejects.toThrow(/timed out/i);
+
+    // Fails fast — nowhere near the 270s library default.
+    expect(Date.now() - start).toBeLessThan(2000);
+    expect(connection.isInitialized()).toBe(false);
+
+    const initSpan = exporter
+      .getFinishedSpans()
+      .find(s => s.name === 'mcp.connection.init');
+    expect(initSpan?.attributes['kustomcp.connection.failure_category']).toBe(
+      'timeout',
+    );
+  });
+});

--- a/tests/unit/suites/connection-timeout.test.ts
+++ b/tests/unit/suites/connection-timeout.test.ts
@@ -141,4 +141,49 @@ describe('connection init is bounded by connectionTimeout (I5)', () => {
       }
     }
   });
+
+  test('failure classification unwraps the axios .cause chain and HTTP status', async () => {
+    const { Client } = require('azure-kusto-data');
+    const cases: Array<[Record<string, unknown>, string]> = [
+      // axios rewrites top-level code to ERR_NETWORK but nests the real cause.
+      [
+        {
+          name: 'AxiosError',
+          code: 'ERR_NETWORK',
+          cause: { code: 'ECONNREFUSED' },
+        },
+        'connection_refused',
+      ],
+      [{ name: 'AxiosError', cause: { code: 'ENOTFOUND' } }, 'dns_resolution'],
+      // HTTP status carried on response even when code is an axios wrapper.
+      [
+        {
+          name: 'AxiosError',
+          code: 'ERR_BAD_REQUEST',
+          response: { status: 403 },
+        },
+        'authz',
+      ],
+      [{ code: 'ERR_NETWORK' }, 'network'],
+    ];
+    for (const [shape, expected] of cases) {
+      exporter.reset();
+      const err = Object.assign(new Error('boom'), shape);
+      Client.mockImplementation(() => ({
+        execute: jest.fn().mockRejectedValue(err),
+      }));
+      const conn = new KustoConnection({
+        authMethod: AuthenticationMethod.AzureCli,
+      });
+      await expect(
+        conn.initialize('https://help.kusto.windows.net', 'db'),
+      ).rejects.toThrow();
+      const span = exporter
+        .getFinishedSpans()
+        .find(s => s.name === 'mcp.connection.init');
+      expect(span?.attributes['kustomcp.connection.failure_category']).toBe(
+        expected,
+      );
+    }
+  });
 });

--- a/tests/unit/suites/connection-timeout.test.ts
+++ b/tests/unit/suites/connection-timeout.test.ts
@@ -84,4 +84,61 @@ describe('connection init is bounded by connectionTimeout (I5)', () => {
       'timeout',
     );
   });
+
+  test('a successful init stamps cloud, source, outcome=success and duration', async () => {
+    const { Client } = require('azure-kusto-data');
+    const mockExecute = jest.fn().mockResolvedValue({
+      primaryResults: [{ data: [{ now: '2026-01-01T00:00:00Z' }] }],
+    });
+    Client.mockImplementation(() => ({ execute: mockExecute }));
+
+    const connection = new KustoConnection({
+      authMethod: AuthenticationMethod.AzureCli,
+    });
+    await connection.initialize(
+      'https://help.kusto.windows.net',
+      'Samples',
+      'auto',
+    );
+
+    const initSpan = exporter
+      .getFinishedSpans()
+      .find(s => s.name === 'mcp.connection.init');
+    const attrs = initSpan!.attributes;
+    expect(attrs['kustomcp.connection.source']).toBe('auto');
+    expect(attrs['kustomcp.cloud']).toBe('public');
+    expect(attrs['kustomcp.connection.outcome']).toBe('success');
+    expect(attrs['kustomcp.connection.timed_out']).toBe(false);
+    expect(typeof attrs['kustomcp.connection.duration_ms']).toBe('number');
+    // proxy_configured is a boolean, never the proxy value.
+    expect(typeof attrs['kustomcp.proxy_configured']).toBe('boolean');
+  });
+
+  test('classifyCloud maps sovereign-cloud host suffixes without leaking the cluster name', async () => {
+    const { Client } = require('azure-kusto-data');
+    Client.mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({ primaryResults: [{ data: [] }] }),
+    }));
+
+    const cases: Array<[string, string]> = [
+      ['https://acme.kusto.usgovcloudapi.net', 'usgov'],
+      ['https://acme.kusto.chinacloudapi.cn', 'china'],
+      ['https://acme.example.com', 'other'],
+    ];
+    for (const [url, expected] of cases) {
+      exporter.reset();
+      const conn = new KustoConnection({
+        authMethod: AuthenticationMethod.AzureCli,
+      });
+      await conn.initialize(url, 'db');
+      const span = exporter
+        .getFinishedSpans()
+        .find(s => s.name === 'mcp.connection.init');
+      expect(span?.attributes['kustomcp.cloud']).toBe(expected);
+      // The org-specific subdomain never appears as an attribute value.
+      for (const v of Object.values(span!.attributes)) {
+        if (typeof v === 'string') expect(v).not.toContain('acme');
+      }
+    }
+  });
 });

--- a/tests/unit/suites/connection.test.ts
+++ b/tests/unit/suites/connection.test.ts
@@ -19,6 +19,11 @@ jest.mock('azure-kusto-data', () => ({
       clusterUrl => `connection-string-for-${clusterUrl}`,
     ),
   },
+  ClientRequestProperties: class {
+    setClientTimeout() {
+      /* no-op for tests */
+    }
+  },
 }));
 jest.mock('../../../src/auth/token-credentials.js', () => ({
   createTokenCredential: jest.fn(() => ({
@@ -111,7 +116,11 @@ describe('Connection Management Unit Tests', () => {
 
       // Verify the mock calls
       expect(mockExecute).toHaveBeenCalledTimes(1);
-      expect(mockExecute).toHaveBeenCalledWith('ContosoSales', 'print now()');
+      expect(mockExecute).toHaveBeenCalledWith(
+        'ContosoSales',
+        'print now()',
+        expect.anything(),
+      );
 
       // Verify connection state
       expect(connection.isInitialized()).toBe(true);
@@ -221,7 +230,11 @@ describe('Connection Management Unit Tests', () => {
       ).rejects.toThrow(KustoConnectionError);
 
       // Verify connection was attempted
-      expect(mockExecute).toHaveBeenCalledWith('ContosoSales', 'print now()');
+      expect(mockExecute).toHaveBeenCalledWith(
+        'ContosoSales',
+        'print now()',
+        expect.anything(),
+      );
 
       // Verify connection is not initialized
       expect(connection.isInitialized()).toBe(false);
@@ -245,6 +258,7 @@ describe('Connection Management Unit Tests', () => {
       expect(mockExecute).toHaveBeenCalledWith(
         'NonExistentDatabase',
         'print now()',
+        expect.anything(),
       );
 
       // Verify connection is not initialized

--- a/tests/unit/suites/error-recording.test.ts
+++ b/tests/unit/suites/error-recording.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression test for the nested-span exception-inflation defect (I1).
+ *
+ * Before the fix, one failure was recorded as an `exception` event on EVERY
+ * span in the executeQueryWithTransformation → executeQuery → kusto.query chain
+ * (inflating failure counts ~3x). `recordSpanError` is now idempotent per error
+ * object, and re-wrapping layers call `carryErrorRecording`, so exactly one
+ * span — the innermost/originating `kusto.query` span — carries the event.
+ *
+ * Red→green: revert the recordSpanError/carryErrorRecording changes and this
+ * expects 1 but observes 3.
+ */
+
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { KustoConnection } from '../../../src/operations/kusto/connection.js';
+import { executeQueryWithTransformation } from '../../../src/operations/kusto/queries.js';
+import {
+  AuthenticationMethod,
+  KustoConfig,
+} from '../../../src/types/config.js';
+
+const exporter = new InMemorySpanExporter();
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+});
+
+const config: KustoConfig = {
+  authMethod: AuthenticationMethod.AzureCli,
+  queryTimeout: 60000,
+};
+
+describe('exception recording is deduped to the originating span', () => {
+  beforeAll(() => {
+    provider.register();
+  });
+
+  beforeEach(() => {
+    exporter.reset();
+  });
+
+  test('a failed query records exactly one exception event across nested spans', async () => {
+    const connection = new KustoConnection(config);
+    // initialize() succeeds: the mocked Client.execute resolves undefined.
+    await connection.initialize('https://help.kusto.windows.net', 'Samples');
+    exporter.reset(); // drop the init span; focus on the query chain
+
+    // Force the actual query execution to reject. `client` is the mocked
+    // Client instance whose `execute` delegates to a per-instance jest.fn.
+    const boom = new Error('kusto boom');
+    boom.name = 'KustoServiceError';
+    (
+      connection as unknown as { client: { executeQuery: jest.Mock } }
+    ).client.executeQuery.mockRejectedValueOnce(boom);
+
+    await expect(
+      executeQueryWithTransformation(connection, 'StormEvents | count'),
+    ).rejects.toThrow();
+
+    const spans = exporter.getFinishedSpans();
+
+    // All three nested spans are present...
+    expect(spans.map(s => s.name)).toEqual(
+      expect.arrayContaining([
+        'kusto.query',
+        'executeQuery',
+        'executeQueryWithTransformation',
+      ]),
+    );
+
+    // ...but the `exception` event is recorded on exactly ONE of them.
+    const exceptionEvents = spans.flatMap(s =>
+      s.events.filter(e => e.name === 'exception'),
+    );
+    expect(exceptionEvents).toHaveLength(1);
+
+    // ...and it lands on the innermost/originating span.
+    const originating = spans.find(s =>
+      s.events.some(e => e.name === 'exception'),
+    );
+    expect(originating?.name).toBe('kusto.query');
+
+    // Every span in the chain still carries error.type + ERROR status.
+    for (const s of spans) {
+      expect(s.attributes['kustomcp.error.type']).toBeDefined();
+    }
+  });
+});

--- a/tests/unit/suites/error-scenarios.test.ts
+++ b/tests/unit/suites/error-scenarios.test.ts
@@ -26,6 +26,11 @@ jest.mock('azure-kusto-data', () => ({
       clusterUrl => `connection-string-for-${clusterUrl}`,
     ),
   },
+  ClientRequestProperties: class {
+    setClientTimeout() {
+      /* no-op for tests */
+    }
+  },
 }));
 
 jest.mock('../../../src/auth/token-credentials.js', () => ({
@@ -279,7 +284,11 @@ describe('Error Scenarios Unit Tests', () => {
       ).rejects.toThrow('ENOTFOUND');
 
       // Verify connection attempt was made with new validation query
-      expect(mockExecute).toHaveBeenCalledWith('ContosoSales', 'print now()');
+      expect(mockExecute).toHaveBeenCalledWith(
+        'ContosoSales',
+        'print now()',
+        expect.anything(),
+      );
     });
 
     test('should handle database connection errors', async () => {
@@ -299,6 +308,7 @@ describe('Error Scenarios Unit Tests', () => {
       expect(mockExecute).toHaveBeenCalledWith(
         'NonExistentDatabase123',
         'print now()',
+        expect.anything(),
       );
     });
 
@@ -330,7 +340,11 @@ describe('Error Scenarios Unit Tests', () => {
         ),
       ).rejects.toThrow('Network error');
 
-      expect(mockExecute).toHaveBeenCalledWith('ContosoSales', 'print now()');
+      expect(mockExecute).toHaveBeenCalledWith(
+        'ContosoSales',
+        'print now()',
+        expect.anything(),
+      );
     });
   });
 
@@ -415,7 +429,11 @@ describe('Error Scenarios Unit Tests', () => {
       ).rejects.toThrow(KustoConnectionError);
 
       // Verify the query was attempted with empty database name
-      expect(mockExecute).toHaveBeenCalledWith('', 'print now()');
+      expect(mockExecute).toHaveBeenCalledWith(
+        '',
+        'print now()',
+        expect.anything(),
+      );
     });
 
     test('should handle invalid parameter types gracefully', async () => {

--- a/tests/unit/suites/identity.test.ts
+++ b/tests/unit/suites/identity.test.ts
@@ -9,6 +9,7 @@ import {
   captureIdentity,
   clearIdentity,
   decodeJwtClaims,
+  getIdentityAttributes,
 } from '../../../src/common/identity.js';
 
 const MSA_TENANT = '9188040d-6c67-4c5b-b112-36a304b66dad';
@@ -106,16 +107,72 @@ describe('anonymous cohort identity', () => {
       );
       expect(a['kustomcp.user_hash']).toBeDefined();
       expect(a['kustomcp.company_hash']).toBeDefined();
+      // identity_state is exposed via getIdentityAttributes, not the raw return.
+      expect(getIdentityAttributes()['kustomcp.identity_state']).toBe(
+        'captured',
+      );
     });
 
-    test('never throws when token acquisition fails', async () => {
+    test('never throws when token acquisition fails; classifies the failure', async () => {
       const a = await captureIdentity(
         'https://help.kusto.windows.net',
         async () => {
           throw new Error('token failed');
         },
       );
-      expect(a).toEqual({});
+      // No cohort hashes when no token resolves...
+      expect(a['kustomcp.user_hash']).toBeUndefined();
+      expect(a['kustomcp.company_hash']).toBeUndefined();
+      // ...but the failure is classified (bounded, non-identifying).
+      expect(a['kustomcp.auth.token_acquired']).toBe(false);
+      expect(a['kustomcp.auth.failure_stage']).toBe('unknown');
+      expect(getIdentityAttributes()['kustomcp.identity_state']).toBe(
+        'unavailable',
+      );
+    });
+
+    test('extracts AADSTS code + failure_stage from a structured AAD error, never a message', async () => {
+      // Shape mirrors @azure/identity AuthenticationError.errorResponse.
+      const authError = Object.assign(new Error('should NOT be read'), {
+        name: 'AuthenticationError',
+        errorResponse: {
+          error: 'interaction_required',
+          errorDescription: 'AADSTS50076: secret tenant detail here',
+          errorCodes: [50076],
+          correlationId: 'do-not-read',
+        },
+      });
+      const a = await captureIdentity(
+        'https://help.kusto.windows.net',
+        async () => {
+          throw authError;
+        },
+      );
+      expect(a['kustomcp.auth.aadsts']).toBe('AADSTS50076');
+      expect(a['kustomcp.auth.failure_stage']).toBe('conditional_access');
+      expect(a['kustomcp.auth.token_acquired']).toBe(false);
+      // No hashes, and nothing echoes the message/description/correlationId.
+      for (const v of Object.values(a)) {
+        if (typeof v === 'string') {
+          expect(v).not.toContain('secret tenant detail');
+          expect(v).not.toContain('do-not-read');
+        }
+      }
+    });
+
+    test('classifies credential-unavailable by class only (no message read)', async () => {
+      const credErr = Object.assign(
+        new Error('Azure CLI not installed / az login required — env specific'),
+        { name: 'CredentialUnavailableError' },
+      );
+      const a = await captureIdentity(
+        'https://help.kusto.windows.net',
+        async () => {
+          throw credErr;
+        },
+      );
+      expect(a['kustomcp.auth.failure_stage']).toBe('credential_unavailable');
+      expect(a['kustomcp.auth.aadsts']).toBeUndefined();
     });
   });
 });

--- a/tests/unit/suites/machine-id.test.ts
+++ b/tests/unit/suites/machine-id.test.ts
@@ -1,0 +1,70 @@
+/**
+ * machine-id persistence: date-floored first_seen (I17) and the onboarding
+ * funnel (I16 — hasConnected / markConnected), plus backward-compat with the
+ * legacy bare-UUID file format.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+describe('machine-id persistence', () => {
+  let dir: string;
+  let prevXdg: string | undefined;
+
+  beforeEach(() => {
+    prevXdg = process.env.XDG_DATA_HOME;
+    dir = mkdtempSync(join(tmpdir(), 'kusto-mcp-mid-'));
+    process.env.XDG_DATA_HOME = dir;
+    jest.resetModules(); // fresh module = fresh in-process markConnected guard
+  });
+
+  afterEach(() => {
+    if (prevXdg === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = prevXdg;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const load = () =>
+    require('../../../src/common/machine-id.js').loadOrCreateMachineId();
+  const mark = () =>
+    require('../../../src/common/machine-id.js').markConnected();
+
+  test('fresh install: JSON store, date-floored first_seen, not yet connected', () => {
+    const id = load();
+    expect(id.isFirstRun).toBe(true);
+    expect(id.hasConnected).toBe(false);
+    expect(id.firstSeen).toMatch(DATE_ONLY); // I17 — no ms-precision jitter
+    // Persisted as JSON (not a bare UUID).
+    const raw = readFileSync(join(dir, 'kusto-mcp', 'machine_id'), 'utf8');
+    expect(() => JSON.parse(raw)).not.toThrow();
+  });
+
+  test('reload returns the same id and is not a first run', () => {
+    const first = load();
+    const second = load();
+    expect(second.machineId).toBe(first.machineId);
+    expect(second.isFirstRun).toBe(false);
+    expect(second.firstSeen).toBe(first.firstSeen);
+  });
+
+  test('legacy bare-UUID file is read; first_seen is date-only', () => {
+    const legacy = '11111111-2222-3333-4444-555555555555';
+    require('node:fs').mkdirSync(join(dir, 'kusto-mcp'), { recursive: true });
+    writeFileSync(join(dir, 'kusto-mcp', 'machine_id'), `${legacy}\n`);
+    const id = load();
+    expect(id.machineId).toBe(legacy);
+    expect(id.hasConnected).toBe(false);
+    expect(id.firstSeen).toMatch(DATE_ONLY);
+  });
+
+  test('markConnected flips hasConnected once and persists it', () => {
+    load();
+    expect(mark()).toBe(true); // first-ever success
+    expect(mark()).toBe(false); // idempotent within the process
+    const reloaded = load();
+    expect(reloaded.hasConnected).toBe(true); // persisted for future runs
+  });
+});


### PR DESCRIPTION
## Why

Live telemetry (1.11.0) surfaced that connection setup succeeds only ~48% of the time, but our deliberately-minimal signals couldn't say *why* — `AxiosError` was opaque (DNS? TLS? proxy? 403? timeout?), auth loops carried no identity, and `connection.init` had an unbounded latency tail (P99 82–135 s). Separately, one failure was recorded as an `exception` event on 2–3 nested spans, inflating failure counts ~2.65×.

This adds diagnostic signal to answer those questions **without weakening anonymity** (every new field is a closed enum / integer / boolean — no raw identity, cluster/db names, query text, or error messages), and fixes the two instrumentation defects. Each change was run through an adversarial privacy review before implementation.

## What changed

- **Idempotent error recording** — one failure now records exactly one `exception` event, on the originating span (`kusto.query` / `mcp.connection.init`). Includes a red→green regression test.
- **Connection failure diagnostics** — `connection.failure_category` (dns/refused/tls/timeout/http_4xx/5xx/authz/auth/throttled/unknown), integer `http.status_code`, `connection.source`, `cloud` (from host **suffix** only), `proxy_configured` (bool, never the value).
- **Auth diagnostics** — `identity_state`, `auth.token_acquired`, `auth.failure_stage`, and the AADSTS code — all read from `@azure/identity`'s **structured** `errorResponse` fields only, never message text.
- **Connection timeout (behavior change)** — init previously inherited the client library's 270 s query default; it's now bounded by `KUSTO_CONNECTION_TIMEOUT` (default 20 s). A hung init fails in ~50 ms in tests.
- **Latency/outcome** — `connection.duration` histogram, `connection.outcome`/`timed_out`, `token_ms`/`connect_ms` phase split.
- **Polish** — `query.size_class`, `query.timeout_kind`, onboarding funnel (`first_success`/`has_connected`), date-floored `machine.first_seen`, `runtime.node_major`, `rows_returned{tool}` label.

## Anonymity

No new field is derived from tenant id, object id, UPN, email, cluster/db name, or IP. AADSTS is a Microsoft error code (app/policy state, not tenant identity) taken solely from the structured `errorCodes` array. Cohort hashes stamped on `kusto.query` are the same values already present on the parent tool span.

## Tests

164 unit tests pass (typecheck + lint + build clean). New tests: exception-dedup (red→green), connection timeout + cloud classification, machine-id funnel/date-floor.

## Deferred

- `connection.failure_stage` — redundant with `failure_category` + `auth.failure_stage`.
- `mcp.client.name` on the init span — needs server→connection plumbing; the value is already on the parent tool span in the same trace.