### PR TITLE
feat: add report-issue tool for filing GitHub issues via pre-filled URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Add this to your `cline_mcp_settings.json` file:
         "initialize-connection",
         "show-tables",
         "show-table",
-        "execute-query"
+        "execute-query",
+        "report-issue"
       ]
     }
   }
@@ -150,8 +151,19 @@ This MCP server provides your AI assistant with tools to:
 - Browse database tables and schemas
 - Execute KQL queries with intelligent result limiting
 - Handle authentication securely through Azure CLI
+- Report a bug or request a feature on GitHub (`report-issue`)
 
 Results are automatically formatted and sized appropriately for AI context windows, so your assistant gets the data it needs without being overwhelmed.
+
+## Reporting a Problem
+
+Hit a bug or want a feature? Ask your AI assistant to **"report a kusto-mcp issue about …"** and it will call the `report-issue` tool.
+
+The tool returns a **pre-filled GitHub issue link** — open it in a browser where you're signed in to GitHub, review the title and body, and click **Submit new issue**. A few things worth knowing:
+
+- **No GitHub token is needed or stored.** The server never files anything on your behalf; the issue is created under your own GitHub account when you submit the form. (You do need a GitHub account to submit.)
+- **Works even when the connection is broken** — it doesn't require an active Kusto connection, so it's the right tool for reporting connection problems.
+- By default a small, non-sensitive **environment footer** (kusto-mcp/Node/OS/MCP-client versions, whether a connection is active, response format, write mode) is appended to help triage. Pass `includeDiagnostics: false` to omit it. It never includes your cluster URL, database, identity, query text, or results.
 
 ## Telemetry & Privacy
 

--- a/src/operations/github/index.ts
+++ b/src/operations/github/index.ts
@@ -1,0 +1,10 @@
+import { buildReportIssueUrl, getIssueRepoSlug } from './report-issue.js';
+
+/**
+ * Export all GitHub operations
+ */
+export { buildReportIssueUrl, getIssueRepoSlug };
+export type {
+  BuildReportIssueUrlOptions,
+  ReportIssueResult,
+} from './report-issue.js';

--- a/src/operations/github/report-issue.ts
+++ b/src/operations/github/report-issue.ts
@@ -1,0 +1,179 @@
+/**
+ * GitHub issue reporting via a pre-filled "new issue" URL.
+ *
+ * The server never creates an issue itself and never holds a GitHub token: it
+ * builds a `https://github.com/<owner>/<repo>/issues/new?title=…&body=…` link
+ * that the user opens in a browser where they are already signed in to GitHub,
+ * reviews, and submits under their own account. This works even when the MCP
+ * runtime has no GitHub account, `gh` CLI, or session — the write happens in
+ * the user's browser, not here.
+ */
+
+/**
+ * Target repository (owner/repo) for filed issues. Kept as a constant (rather
+ * than read from package.json via `import.meta`) so the module loads cleanly
+ * under the CommonJS-compiled unit test runner. Forks change this one line.
+ */
+const DEFAULT_SLUG = 'johnib/kusto-mcp';
+
+/**
+ * Practical cap on the whole issue URL. GitHub rejects excessively long URLs
+ * (HTTP 414); ~8k keeps us comfortably under real-world limits while leaving
+ * room for the title and labels.
+ */
+const MAX_URL_LENGTH = 8000;
+
+/**
+ * GitHub caps issue titles at 256 characters. Clamp to the same bound so the
+ * "title is always preserved" invariant can't itself push the URL over
+ * {@link MAX_URL_LENGTH}.
+ */
+const MAX_TITLE_LENGTH = 256;
+
+const TRUNCATION_MARKER = '\n\n…[truncated]';
+
+export interface BuildReportIssueUrlOptions {
+  /** Issue title (required). */
+  title: string;
+  /** Freeform issue body (Markdown). */
+  body?: string;
+  /** Labels to pre-select, e.g. ['bug']. Commas inside a label are stripped. */
+  labels?: string[];
+  /**
+   * Non-sensitive environment info appended as a footer when
+   * `includeDiagnostics` is not false. Values that are undefined/null/empty are
+   * skipped.
+   */
+  diagnostics?: Record<string, string | number | boolean | undefined>;
+  /** Append the diagnostics footer. Defaults to true. */
+  includeDiagnostics?: boolean;
+}
+
+export interface ReportIssueResult {
+  /** The pre-filled GitHub new-issue URL. */
+  url: string;
+  /** The owner/repo the URL targets. */
+  slug: string;
+  /** True when the freeform body was truncated to fit the URL budget. */
+  bodyTruncated: boolean;
+  /** True when the diagnostics footer was included in the final URL. */
+  diagnosticsIncluded: boolean;
+}
+
+/** The default target `owner/repo` for filed issues. */
+export function getIssueRepoSlug(): string {
+  return DEFAULT_SLUG;
+}
+
+/** Clamp an over-long title so it can't push the URL past the budget. */
+function clampTitle(title: string): string {
+  return title.length > MAX_TITLE_LENGTH
+    ? `${title.slice(0, MAX_TITLE_LENGTH - 1)}…`
+    : title;
+}
+
+/** Strip commas (which delimit the labels param), trim, and drop empties. */
+function sanitizeLabels(labels?: string[]): string[] {
+  return (labels ?? [])
+    .map(label => label.replace(/,/g, ' ').trim())
+    .filter(label => label.length > 0);
+}
+
+function renderDiagnostics(
+  diagnostics?: Record<string, string | number | boolean | undefined>,
+): string {
+  if (!diagnostics) return '';
+  const lines = Object.entries(diagnostics)
+    .filter(
+      ([, value]) =>
+        value !== undefined && value !== null && String(value).length > 0,
+    )
+    .map(([key, value]) => `- ${key}: ${String(value)}`);
+  if (lines.length === 0) return '';
+  return ['---', '### Environment (auto-collected)', ...lines].join('\n');
+}
+
+function joinBody(body: string, diagnosticsBlock: string): string {
+  return [body.trim() ? body : '', diagnosticsBlock]
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function composeUrl(
+  slug: string,
+  title: string,
+  body: string,
+  labels: string[],
+): string {
+  const url = new URL(`https://github.com/${slug}/issues/new`);
+  url.searchParams.set('title', title);
+  if (body) url.searchParams.set('body', body);
+  if (labels.length > 0) url.searchParams.set('labels', labels.join(','));
+  return url.toString();
+}
+
+/**
+ * Largest prefix of `rawBody` (plus a truncation marker) whose resulting URL
+ * still fits the budget, keeping title and labels intact.
+ */
+function largestBodyThatFits(
+  slug: string,
+  title: string,
+  rawBody: string,
+  labels: string[],
+): string {
+  let lo = 0;
+  let hi = rawBody.length;
+  let best = 0;
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    const candidate = rawBody.slice(0, mid) + TRUNCATION_MARKER;
+    if (composeUrl(slug, title, candidate, labels).length <= MAX_URL_LENGTH) {
+      best = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return rawBody.slice(0, best) + TRUNCATION_MARKER;
+}
+
+/**
+ * Build a pre-filled GitHub new-issue URL. When the URL exceeds the length
+ * budget it degrades gracefully: first the diagnostics footer is dropped, then
+ * the freeform body is truncated — the title and labels are always preserved.
+ */
+export function buildReportIssueUrl(
+  opts: BuildReportIssueUrlOptions,
+): ReportIssueResult {
+  const slug = getIssueRepoSlug();
+  const title = clampTitle(opts.title);
+  const rawBody = opts.body ?? '';
+  const labels = sanitizeLabels(opts.labels);
+  const diagnosticsBlock =
+    opts.includeDiagnostics === false
+      ? ''
+      : renderDiagnostics(opts.diagnostics);
+
+  let diagnosticsIncluded = diagnosticsBlock.length > 0;
+  let bodyTruncated = false;
+
+  let bodyText = joinBody(rawBody, diagnosticsBlock);
+  let url = composeUrl(slug, title, bodyText, labels);
+
+  // Over budget: drop the diagnostics footer first (it is the least valuable).
+  if (url.length > MAX_URL_LENGTH && diagnosticsIncluded) {
+    diagnosticsIncluded = false;
+    bodyText = rawBody;
+    url = composeUrl(slug, title, bodyText, labels);
+  }
+
+  // Still over budget: truncate the freeform body, keeping title + labels.
+  if (url.length > MAX_URL_LENGTH) {
+    bodyText = largestBodyThatFits(slug, title, rawBody, labels);
+    bodyTruncated = true;
+    url = composeUrl(slug, title, bodyText, labels);
+  }
+
+  return { url, slug, bodyTruncated, diagnosticsIncluded };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,7 @@ import {
   showTables,
 } from './operations/kusto/index.js';
 import { showFunctions } from './operations/kusto/tables.js';
+import { buildReportIssueUrl } from './operations/github/index.js';
 import { PromptManager } from './operations/prompts/index.js';
 import { KustoConfig, validateConfig } from './types/config.js';
 
@@ -62,6 +63,31 @@ const ShowFunctionSchema = z.object({
   functionName: z
     .string()
     .describe('The name of the function to get details for'),
+});
+
+const ReportIssueSchema = z.object({
+  title: z
+    .string()
+    .min(1)
+    .max(256)
+    .describe('Short summary line for the GitHub issue'),
+  body: z
+    .string()
+    .optional()
+    .describe(
+      'Full description (Markdown): what happened, expected vs actual behavior, and steps to reproduce.',
+    ),
+  labels: z
+    .array(z.string())
+    .optional()
+    .describe("Labels to pre-select, e.g. ['bug'] or ['enhancement']."),
+  includeDiagnostics: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      'Append non-sensitive environment info (kusto-mcp/node/OS/MCP-client versions, connection state, response format, write mode). Never includes cluster URL, database, identity, query text, or results.',
+    ),
 });
 
 /**
@@ -173,6 +199,12 @@ export function createKustoServer(config: KustoConfig): Server {
           description:
             'Show details of a specific function, including its code and parameters',
           inputSchema: z.toJSONSchema(ShowFunctionSchema),
+        },
+        {
+          name: 'report-issue',
+          description:
+            'Report a bug or request a feature for kusto-mcp on GitHub. Returns a pre-filled GitHub issue link you open in your browser and submit under your own GitHub account — no GitHub token is used or stored, and no Kusto connection is required.',
+          inputSchema: z.toJSONSchema(ReportIssueSchema),
         },
       ],
     };
@@ -476,6 +508,82 @@ export function createKustoServer(config: KustoConfig): Server {
                 content: [
                   { type: 'text', text: JSON.stringify(result, null, 2) },
                 ],
+              };
+            }
+
+            case 'report-issue': {
+              const args = ReportIssueSchema.parse(request.params.arguments);
+
+              // Whitelisted, low-sensitivity diagnostics only. Never the
+              // cluster URL, database, identity, query text, or results.
+              const diagnostics = {
+                'kusto-mcp': VERSION,
+                node: process.version,
+                os: `${process.platform}/${process.arch}`,
+                'mcp client': clientInfo?.name
+                  ? `${clientInfo.name} ${clientInfo.version ?? ''}`.trim()
+                  : 'unknown',
+                'kusto connected': connection ? 'yes' : 'no',
+                'response format': validatedConfig.responseFormat ?? 'json',
+                'write mode':
+                  (validatedConfig.allowWriteOperations ?? true) ? 'on' : 'off',
+              };
+
+              const report = buildReportIssueUrl({
+                title: args.title,
+                body: args.body,
+                labels: args.labels,
+                diagnostics,
+                includeDiagnostics: args.includeDiagnostics,
+              });
+
+              // Privacy-safe telemetry: counts/flags only, never the text.
+              span.setAttribute(
+                'kustomcp.report.body_len',
+                (args.body ?? '').length,
+              );
+              span.setAttribute(
+                'kustomcp.report.label_count',
+                args.labels?.length ?? 0,
+              );
+              span.setAttribute(
+                'kustomcp.report.url_truncated',
+                report.bodyTruncated,
+              );
+              span.setAttribute(
+                'kustomcp.report.diagnostics_included',
+                report.diagnosticsIncluded,
+              );
+
+              const notes: string[] = [];
+              if (report.bodyTruncated) {
+                notes.push(
+                  'Note: the body was truncated to fit GitHub’s URL length limit — you can paste any missing detail after opening the link.',
+                );
+              }
+              if (
+                args.includeDiagnostics !== false &&
+                !report.diagnosticsIncluded
+              ) {
+                notes.push(
+                  'Note: the environment footer was dropped to fit the URL length limit.',
+                );
+              }
+
+              const text = [
+                `[Open a pre-filled GitHub issue for kusto-mcp](${report.url})`,
+                '',
+                'Open this link in a browser where you are signed in to GitHub, review the pre-filled title and body, then click **Submit new issue**. Nothing is filed automatically — this server holds no GitHub token and creates nothing on your behalf.',
+                ...(notes.length > 0 ? ['', ...notes] : []),
+                '',
+                'If the link is not clickable, copy this URL:',
+                '```',
+                report.url,
+                '```',
+              ].join('\n');
+
+              return {
+                content: [{ type: 'text', text }],
               };
             }
 

--- a/tests/e2e/suites/report-issue.test.ts
+++ b/tests/e2e/suites/report-issue.test.ts
@@ -1,0 +1,81 @@
+import { MCPTestClient } from '../helpers/mcp-test-client.js';
+
+/**
+ * report-issue E2E tests.
+ *
+ * Unlike every other tool, report-issue must work WITHOUT a Kusto connection —
+ * its primary use case is reporting a broken connection. These tests never call
+ * initialize-connection.
+ */
+describe('Report Issue', () => {
+  let client: MCPTestClient;
+
+  beforeEach(async () => {
+    client = new MCPTestClient();
+    await client.startServer();
+  });
+
+  afterEach(async () => {
+    if (client) {
+      await client.stopServer();
+    }
+  });
+
+  test('is advertised in the tools list', async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((tool: { name: string }) => tool.name);
+    expect(names).toContain('report-issue');
+  });
+
+  test('returns a pre-filled GitHub issue URL without a connection', async () => {
+    const response = await client.callTool('report-issue', {
+      title: 'Cannot connect to cluster',
+      body: 'initialize-connection throws AADSTS error.\nExpected it to connect.',
+      labels: ['bug'],
+    });
+
+    expect(response.isError).toBeFalsy();
+
+    const text: string = response.content[0].text;
+    const match = text.match(
+      /https:\/\/github\.com\/[^\s)]+\/issues\/new\?[^\s)]+/,
+    );
+    expect(match).not.toBeNull();
+
+    const url = new URL(match![0]);
+    expect(url.host).toBe('github.com');
+    expect(url.pathname).toBe('/johnib/kusto-mcp/issues/new');
+    expect(url.searchParams.get('title')).toBe('Cannot connect to cluster');
+    expect(url.searchParams.get('labels')).toBe('bug');
+    // Body carries the report plus the auto-collected environment footer, which
+    // records that no connection was established.
+    const body = url.searchParams.get('body') ?? '';
+    expect(body).toContain('AADSTS');
+    expect(body).toContain('### Environment (auto-collected)');
+    expect(body).toContain('kusto connected: no');
+  });
+
+  test('omits the diagnostics footer when includeDiagnostics is false', async () => {
+    const response = await client.callTool('report-issue', {
+      title: 'Feature request',
+      body: 'Please add X.',
+      includeDiagnostics: false,
+    });
+
+    expect(response.isError).toBeFalsy();
+    const text: string = response.content[0].text;
+    const url = new URL(
+      text.match(/https:\/\/github\.com\/[^\s)]+\/issues\/new\?[^\s)]+/)![0],
+    );
+    const body = url.searchParams.get('body') ?? '';
+    expect(body).toBe('Please add X.');
+    expect(body).not.toContain('### Environment');
+  });
+
+  test('rejects a call with a missing title', async () => {
+    const response = await client.callTool('report-issue', {
+      body: 'no title provided',
+    });
+    expect(response.isError).toBe(true);
+  });
+});

--- a/tests/unit/suites/report-issue.test.ts
+++ b/tests/unit/suites/report-issue.test.ts
@@ -1,0 +1,176 @@
+/**
+ * report-issue Unit Tests
+ * Tests the pure pre-filled GitHub issue URL builder and repo-slug derivation.
+ */
+
+import {
+  buildReportIssueUrl,
+  getIssueRepoSlug,
+} from '../../../src/operations/github/report-issue.js';
+
+const MAX_URL_LENGTH = 8000;
+
+describe('report-issue URL builder', () => {
+  describe('getIssueRepoSlug', () => {
+    test('returns the canonical hardcoded kusto-mcp repo', () => {
+      expect(getIssueRepoSlug()).toBe('johnib/kusto-mcp');
+    });
+  });
+
+  describe('basic structure', () => {
+    test('targets the GitHub new-issue endpoint for the derived repo', () => {
+      const { url, slug } = buildReportIssueUrl({ title: 'Hello' });
+      const parsed = new URL(url);
+
+      expect(parsed.protocol).toBe('https:');
+      expect(parsed.host).toBe('github.com');
+      expect(parsed.pathname).toBe('/johnib/kusto-mcp/issues/new');
+      expect(slug).toBe('johnib/kusto-mcp');
+      expect(parsed.searchParams.get('title')).toBe('Hello');
+    });
+  });
+
+  describe('encoding', () => {
+    test('round-trips special characters, spaces, and newlines in the body', () => {
+      const body = 'Line one\nLine two & <tag> "quote" 100% + ?done';
+      const { url } = buildReportIssueUrl({ title: 'T', body });
+      // Raw URL must be percent-encoded, not carry literal newlines/spaces.
+      expect(url).not.toContain('\n');
+      expect(url).not.toContain(' ');
+      // ...but decodes back to exactly what was passed in.
+      expect(new URL(url).searchParams.get('body')).toBe(body);
+    });
+  });
+
+  describe('labels', () => {
+    test('comma-joins labels into the labels param', () => {
+      const { url } = buildReportIssueUrl({
+        title: 'T',
+        labels: ['bug', 'enhancement'],
+      });
+      expect(new URL(url).searchParams.get('labels')).toBe('bug,enhancement');
+    });
+
+    test('strips commas inside a single label so it cannot inject extra labels', () => {
+      const { url } = buildReportIssueUrl({
+        title: 'T',
+        labels: ['needs,triage'],
+      });
+      expect(new URL(url).searchParams.get('labels')).toBe('needs triage');
+    });
+
+    test('drops empty/whitespace-only labels', () => {
+      const { url } = buildReportIssueUrl({
+        title: 'T',
+        labels: ['bug', '', '  '],
+      });
+      expect(new URL(url).searchParams.get('labels')).toBe('bug');
+    });
+
+    test('omits the labels param entirely when there are none', () => {
+      const { url } = buildReportIssueUrl({ title: 'T' });
+      expect(new URL(url).searchParams.has('labels')).toBe(false);
+    });
+  });
+
+  describe('diagnostics footer', () => {
+    const diagnostics = {
+      'kusto-mcp': '1.2.3',
+      node: 'v20.0.0',
+      'kusto connected': 'no',
+      empty: '',
+      missing: undefined,
+    };
+
+    test('appends the footer by default and reports diagnosticsIncluded', () => {
+      const result = buildReportIssueUrl({
+        title: 'T',
+        body: 'hi',
+        diagnostics,
+      });
+      const decoded = new URL(result.url).searchParams.get('body') ?? '';
+
+      expect(result.diagnosticsIncluded).toBe(true);
+      expect(decoded).toContain('hi');
+      expect(decoded).toContain('### Environment (auto-collected)');
+      expect(decoded).toContain('- kusto-mcp: 1.2.3');
+      expect(decoded).toContain('- kusto connected: no');
+      // Empty/undefined diagnostic values are skipped.
+      expect(decoded).not.toContain('- empty:');
+      expect(decoded).not.toContain('- missing:');
+    });
+
+    test('omits the footer when includeDiagnostics is false', () => {
+      const result = buildReportIssueUrl({
+        title: 'T',
+        body: 'hi',
+        diagnostics,
+        includeDiagnostics: false,
+      });
+      const decoded = new URL(result.url).searchParams.get('body') ?? '';
+
+      expect(result.diagnosticsIncluded).toBe(false);
+      expect(decoded).toBe('hi');
+    });
+
+    test('diagnosticsIncluded is false when no diagnostics are supplied', () => {
+      const result = buildReportIssueUrl({ title: 'T', body: 'hi' });
+      expect(result.diagnosticsIncluded).toBe(false);
+    });
+  });
+
+  describe('length budget', () => {
+    test('drops diagnostics before truncating the body', () => {
+      // Body fits comfortably alone, but not once a large footer is appended.
+      const body = 'a'.repeat(7000);
+      const diagnostics = { detail: 'd'.repeat(1500) };
+
+      const result = buildReportIssueUrl({ title: 'T', body, diagnostics });
+
+      expect(result.url.length).toBeLessThanOrEqual(MAX_URL_LENGTH);
+      expect(result.diagnosticsIncluded).toBe(false);
+      expect(result.bodyTruncated).toBe(false);
+      // Full body preserved, no footer.
+      expect(new URL(result.url).searchParams.get('body')).toBe(body);
+    });
+
+    test('truncates an oversized body while keeping title and labels', () => {
+      const body = 'x'.repeat(20000);
+      const result = buildReportIssueUrl({
+        title: 'Important title',
+        body,
+        labels: ['bug'],
+        diagnostics: { node: 'v20' },
+      });
+      const parsed = new URL(result.url);
+      const decodedBody = parsed.searchParams.get('body') ?? '';
+
+      expect(result.url.length).toBeLessThanOrEqual(MAX_URL_LENGTH);
+      expect(result.bodyTruncated).toBe(true);
+      expect(result.diagnosticsIncluded).toBe(false);
+      expect(decodedBody).toContain('…[truncated]');
+      expect(decodedBody.length).toBeLessThan(body.length);
+      // Title and labels are never sacrificed.
+      expect(parsed.searchParams.get('title')).toBe('Important title');
+      expect(parsed.searchParams.get('labels')).toBe('bug');
+    });
+
+    test('stays within budget even when body is enormous and full of encoded chars', () => {
+      const body = '\n& '.repeat(10000); // each char percent-expands
+      const result = buildReportIssueUrl({ title: 'T', body });
+      expect(result.url.length).toBeLessThanOrEqual(MAX_URL_LENGTH);
+      expect(result.bodyTruncated).toBe(true);
+    });
+
+    test('clamps an oversized title so the budget still holds', () => {
+      const title = 'T'.repeat(20000);
+      const result = buildReportIssueUrl({ title });
+      const parsedTitle = new URL(result.url).searchParams.get('title') ?? '';
+
+      expect(result.url.length).toBeLessThanOrEqual(MAX_URL_LENGTH);
+      // Clamped to <= 256 chars and marked with an ellipsis.
+      expect(parsedTitle.length).toBeLessThanOrEqual(256);
+      expect(parsedTitle.endsWith('…')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## What & why

Adds a `report-issue` MCP tool so users can file a kusto-mcp bug/feature request from their AI assistant.

The mechanism is a **pre-filled GitHub new-issue URL** (`github.com/johnib/kusto-mcp/issues/new?title=…&body=…&labels=…`). The user opens the link, reviews the pre-filled form, and clicks **Submit** — the issue is created under **their own** GitHub account.

Why this shape (vs. calling the GitHub API directly):

- **No token, no session, no secret.** Creating an issue via the REST API requires a credential (`401` otherwise), and we can't assume the MCP runtime has a `gh` session or PAT. The prefilled URL moves the write to the one place a GitHub login reliably exists — the user's browser.
- **Works with no Kusto connection.** Its primary use case is reporting a *broken connection*, so the tool deliberately does not call `requireConnection()`.
- Rejected alternatives (shipped PAT, maintainer proxy/GitHub App) for v1: secret-scanning revocation, shared identity, spam/abuse liability.

The only case it can't cover is a user with literally no GitHub account — inherent to GitHub, documented honestly in the tool text.

## Changes

- `src/operations/github/report-issue.ts` — pure `buildReportIssueUrl` + `getIssueRepoSlug`. Length budget (~8k): drops the diagnostics footer first, then truncates the body, **always keeping title + labels**. Commas inside a label are stripped so they can't inject extra labels. Target repo is a fixed constant (`johnib/kusto-mcp`).
- `src/server.ts` — `ReportIssueSchema`, ListTools entry, and a `report-issue` case (no `requireConnection`). Sets **privacy-safe** span attributes only (`body_len`, `label_count`, `url_truncated`, `diagnostics_included`) — never the title/body text.
- Optional environment footer: kusto-mcp/node/OS/MCP-client versions, connection state (yes/no), response format, write mode. `includeDiagnostics: false` omits it. Never includes cluster URL, database, identity, query text, or results.
- Docs: README (`Reporting a Problem`).

## Testing

- **Unit** (`tests/unit/suites/report-issue.test.ts`): URL structure/host, encoding round-trip, labels + comma-stripping, diagnostics on/off, diagnostics-dropped-before-truncation, body truncation budget + marker. `npm test` → 178 passing.
- **E2E** (`tests/e2e/suites/report-issue.test.ts`): spawns the real server, lists tools, and calls `report-issue` **without** `initialize-connection` — asserts a valid `issues/new` URL and the `kusto connected: no` footer. 4 passing.
- Also verified by hand against the built `dist/index.js` over stdio.

CI gates (lint, unit, build across Node 18/20/22/24) pass locally.