### PR TITLE
fix(stdio): exit on stdin 'error' to avoid orphaned server processes

### DIFF
--- a/src/common/lifecycle.ts
+++ b/src/common/lifecycle.ts
@@ -1,0 +1,45 @@
+import type { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+/**
+ * The stdin end-of-stream signals that indicate the MCP client has gone away.
+ *
+ * A stdio MCP server's lifetime is bound to its client: once the client closes
+ * the pipe the server must exit, otherwise it lingers as an orphan. There are two
+ * distinct ways the pipe can go away and BOTH must trigger shutdown:
+ *
+ *   - a *clean* close — the client ends the stream: `'end'` / `'close'`.
+ *   - an *abrupt* teardown — the client (or an intermediate wrapper such as an
+ *     `npx`/`cmd.exe` launcher) is killed and the pipe breaks. On Windows this
+ *     commonly surfaces as an `'error'` on stdin rather than a graceful `'end'`.
+ *
+ * The `'error'` arm is the important one: without it, an abrupt disconnect leaves
+ * the `'end'`/`'close'` handlers un-fired, so the server keeps running long after
+ * its client is gone (observed in the wild as orphaned, CPU-burning processes).
+ */
+export interface StdioLifecycleDeps {
+  /** The active transport; its `onclose` is wired to the same shutdown path. */
+  transport: Pick<StdioServerTransport, 'onclose'>;
+  /** Process stdin (or any EventEmitter exposing `once`). */
+  stdin: Pick<NodeJS.ReadStream, 'once'>;
+  /** Invoked once when the client disconnects, by any of the signals above. */
+  onDisconnect: () => void;
+}
+
+/**
+ * Wire every client-disconnect signal to `onDisconnect`. The callback is expected
+ * to be idempotent (guarded against re-entry) because more than one of these
+ * events can fire for a single disconnect.
+ */
+export function installStdioLifecycle({
+  transport,
+  stdin,
+  onDisconnect,
+}: StdioLifecycleDeps): void {
+  transport.onclose = onDisconnect;
+  stdin.once('end', onDisconnect);
+  stdin.once('close', onDisconnect);
+  // Abrupt broken-pipe teardown (e.g. the client process is killed on Windows)
+  // arrives as an 'error', not a clean 'end'. Attaching a listener both routes it
+  // to shutdown AND prevents the unhandled-'error' path.
+  stdin.once('error', onDisconnect);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   startTelemetry,
 } from './common/telemetry.js';
 import { createKustoServer } from './server.js';
+import { installStdioLifecycle } from './common/lifecycle.js';
 import { VERSION } from './common/version.js';
 import {
   AuthenticationMethod,
@@ -222,10 +223,12 @@ async function runServer() {
   // telemetry export holds a live socket that would otherwise keep the event
   // loop from draining, so the process must be told to shut down. shutdownAndExit
   // then force-exits within the bounded flush race regardless of pending sockets.
+  //
+  // Both a clean close ('end'/'close') AND an abrupt broken pipe ('error') must
+  // trigger shutdown — the latter is how a killed client/wrapper disconnect shows
+  // up on Windows, and without it the server is left running as an orphan.
   const onDisconnect = () => void shutdownAndExit('client-disconnect');
-  transport.onclose = onDisconnect;
-  process.stdin.once('end', onDisconnect);
-  process.stdin.once('close', onDisconnect);
+  installStdioLifecycle({ transport, stdin: process.stdin, onDisconnect });
   await server.connect(transport);
 
   criticalLog('Kusto MCP Server running on stdio');

--- a/tests/unit/suites/lifecycle.test.ts
+++ b/tests/unit/suites/lifecycle.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Stdio lifecycle wiring: every client-disconnect signal — a clean end/close AND
+ * an abrupt broken-pipe 'error' — must route to the shutdown callback exactly the
+ * same way, so the server can never be left running after its client is gone.
+ */
+
+import { EventEmitter } from 'node:events';
+import { installStdioLifecycle } from '../../../src/common/lifecycle.js';
+
+type Stdin = Pick<NodeJS.ReadStream, 'once'>;
+
+function wire() {
+  const stdin = new EventEmitter() as unknown as Stdin & EventEmitter;
+  const transport: { onclose?: () => void } = {};
+  const onDisconnect = jest.fn();
+  installStdioLifecycle({
+    transport: transport as never,
+    stdin,
+    onDisconnect,
+  });
+  return { stdin, transport, onDisconnect };
+}
+
+describe('installStdioLifecycle', () => {
+  it('wires transport.onclose to the disconnect handler', () => {
+    const { transport, onDisconnect } = wire();
+    expect(transport.onclose).toBe(onDisconnect);
+  });
+
+  it.each(['end', 'close', 'error'] as const)(
+    "shuts down on stdin '%s'",
+    signal => {
+      const { stdin, onDisconnect } = wire();
+      (stdin as unknown as EventEmitter).emit(signal, new Error('broken pipe'));
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("routes an abrupt stdin 'error' to shutdown (regression: broken-pipe orphan)", () => {
+    // The pre-fix code listened only for 'end'/'close'. A killed client on Windows
+    // breaks the pipe as an 'error', which previously left the server running.
+    const { stdin, onDisconnect } = wire();
+    (stdin as unknown as EventEmitter).emit('error', new Error('EPIPE'));
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

A stdio MCP server's lifetime is bound to its client: when the client goes away, the server must exit. The current disconnect wiring in `runServer()` only listens for:

- `transport.onclose`
- `process.stdin` `'end'`
- `process.stdin` `'close'`

That covers a **clean** client shutdown. It does **not** cover an **abrupt** teardown — when the client process (or an intermediate `npx` / `cmd.exe` launcher) is killed and the pipe breaks. On Windows that broken pipe commonly surfaces as an `'error'` event on stdin rather than a graceful `'end'`/`'close'`. Because nothing routed `'error'` to shutdown, the server kept running after its parent was gone.

## Motivation (what I observed)

On Windows, after an MCP client (GitHub Copilot CLI) session was closed, I found **dozens of orphaned `kusto-mcp` node processes** still alive and collectively burning multiple CPU cores. Their grandparent client processes were dead. The server had been launched via `cmd /c npx -y kusto-mcp@latest`, so between the client and the server sits an `npx`/`cmd.exe` wrapper; when that chain is torn down abruptly the server's stdin breaks rather than ending cleanly.

## Fix

Extract the disconnect wiring into a small, testable `installStdioLifecycle()` helper and add the missing stdin **`'error'`** arm alongside `'end'`/`'close'` and `transport.onclose`:

```ts
transport.onclose = onDisconnect;
stdin.once('end', onDisconnect);
stdin.once('close', onDisconnect);
stdin.once('error', onDisconnect); // abrupt broken-pipe teardown (Windows)
```

`shutdownAndExit` is already idempotent (guarded by a `shuttingDown` flag), so multiple signals firing for a single disconnect are safe. Attaching an `'error'` listener also prevents an unhandled-`'error'` on the stream.

## Tests

Adds `tests/unit/suites/lifecycle.test.ts` (runs in the existing `unit` CI project):

- wires `transport.onclose` to the disconnect handler
- shuts down on stdin `'end'`
- shuts down on stdin `'close'`
- shuts down on stdin `'error'`
- routes an abrupt stdin `'error'` to shutdown (broken-pipe orphan regression)

All 5 pass. `npm run build` passes. `eslint` reports 0 errors/0 warnings on the changed files.

## Honesty / scope note

I was **not** able to deterministically reproduce the exact CPU spin in an isolated harness — clean-disconnect paths all exit correctly there, and I could not synthesize the precise Windows broken-pipe condition outside the real client. This PR therefore closes a concrete, verifiable gap in the disconnect handling (the unhandled stdin `'error'` path that leaves the server orphaned on abrupt teardown) rather than claiming to be a proven fix for one specific spin. It's a low-risk hardening change backed by unit tests; happy to iterate if you'd like a different shape.
