### PR TITLE
fix(ci): repair @claude workflow auth and restrict trigger to owner

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   claude-review:
-    if: github.actor != 'dependabot[bot]'
+    # Skip fork PRs: they run without the base repo's secrets/OIDC, so the
+    # reviewer can't authenticate and the job fails. Review external
+    # contributions on demand by commenting `@claude` (see claude.yml).
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     # ANTHROPIC_BASE_URL must be job-level: a `uses:` step's env block does not
     # reach the composite action's `${{ env.* }}` context, so a step-level value

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,4 @@
+# managed-by: github-policies
 name: Claude Code
 
 on:
@@ -12,40 +13,38 @@ on:
 
 jobs:
   claude:
+    # Only the repo owner (johnib) may trigger Claude. `@claude` runs on fork PRs
+    # with the base repo's secrets, so pinning the actor prevents anyone else —
+    # collaborators, org members, or external contributors — from firing it.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == 'johnib' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
+    # ANTHROPIC_BASE_URL must be job-level: a `uses:` step's env block does not
+    # reach the composite action's `${{ env.* }}` context.
+    env:
+      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CUSTOM_ANTHROPIC_API_KEY }}
-          # This is an optional setting that allows Claude to read CI results on PRs
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: '--model claude-opus-4-8 --allowedTools "WebFetch,WebSearch,Bash(npm:*),Bash(npx:*),Bash(bun:*),Bash(git:*),Bash(gh:*),Bash(curl:*),Read,Glob,Grep,Edit,Write"'
           additional_permissions: |
             actions: read
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'


### PR DESCRIPTION
## Problem

`.github/workflows/claude.yml` had drifted from the managed `github-policies` template and broke the `@claude` flow:

- referenced a **non-existent** secret `CUSTOM_ANTHROPIC_API_KEY` → empty key → auth failure
- set `ANTHROPIC_BASE_URL` at **step level**, where it never reaches the composite action → custom endpoint silently ignored
- lost the `# managed-by:` marker, so the policy sync stopped healing it

Net effect: every `@claude` run failed at authentication (confirmed on a live run against fork PR #169).

Separately, the auto-review (`claude-code-review.yml`) always red-X'd on **fork** PRs, because fork `pull_request` runs get no secrets/OIDC.

## Fix

- **`claude.yml`**: re-align to the canonical template — correct `ANTHROPIC_API_KEY`, **job-level** `ANTHROPIC_BASE_URL` (same wiring as the working reviewer), marker restored. Pin the trigger to `github.actor == 'johnib'` so **only the owner** can fire it — important now that `@claude` runs on fork PRs with the base repo's secrets.
- **`claude-code-review.yml`**: skip fork PRs (`head.repo.full_name == github.repository`). External contributions get reviewed on demand via `@claude`.

## Note

Source-of-truth templates in `github-policies/defaults/` are being updated to match, so future syncs keep this aligned. Two other repos (`copilot-api`, `openstatus`) have the same orphaned `claude.yml` and need the same repair.