### PR TITLE
fix: exit orphaned stdio server when MCP client dies (Windows CPU leak)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,14 @@ KUSTO_MIN_RESPONSE_ROWS=1       # Minimum rows to return when data exists (defau
 # Safety
 KUSTO_ALLOW_WRITE_OPERATIONS=true # Allow write/management commands (default: true). Set false for read-only.
 
+# Orphan / disconnect handling (Windows)
+# On Windows the client launches the server through intermediary cmd/npx
+# processes that hold stdin open, so a dying client may not close the pipe and
+# the server can be orphaned (spinning, burning CPU). A best-effort watchdog
+# watches the ancestor process chain and exits when the client goes away.
+KUSTO_ENABLE_PARENT_WATCHDOG=true          # Enable the orphan watchdog (default: true). Set false to disable.
+KUSTO_PARENT_WATCHDOG_INTERVAL_MS=60000    # Ancestor liveness poll interval in ms (default: 60000, min: 1000).
+
 # OpenTelemetry / Telemetry Configuration
 # kusto-mcp ALWAYS reports anonymous usage telemetry to the maintainer's
 # Honeycomb (see README > Telemetry & Privacy) — there is no disable switch. No

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -21,9 +21,39 @@ KUSTO_MIN_RESPONSE_ROWS=1  # Minimum rows to return when data exists (default: 1
 # Safety
 KUSTO_ALLOW_WRITE_OPERATIONS=true  # Allow write/management commands (default: true). Set false for read-only.
 
+# Orphan / disconnect handling (Windows)
+KUSTO_ENABLE_PARENT_WATCHDOG=true        # Enable the orphan watchdog (default: true). Set false to disable.
+KUSTO_PARENT_WATCHDOG_INTERVAL_MS=60000  # Ancestor liveness poll interval in ms (default: 60000, min: 1000).
+
 # OpenTelemetry Configuration (optional)
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317/v1/traces
 ```
+
+## Orphan / Disconnect Handling
+
+A stdio MCP server is meant to exit when the client closes its stdin. On
+Windows the client usually launches the server through intermediary processes
+(e.g. `cmd /c npx -y kusto-mcp@latest`, which spawns another `cmd` + `node`).
+Those intermediaries inherit and hold the write end of the server's stdin, so
+when the client exits the pipe is never closed — stdin never reaches EOF, the
+disconnect handlers never fire, and the server is orphaned, spinning on the
+half-dead pipe and consuming CPU indefinitely.
+
+To prevent this, the server runs a **best-effort watchdog** (Windows only; on
+POSIX stdin EOF is reliable): it snapshots its ancestor process chain at startup
+and, every `KUSTO_PARENT_WATCHDOG_INTERVAL_MS`, checks that each ancestor still
+exists. If any ancestor has exited — which is what happens when the client or
+editor closes — the server shuts down cleanly, releasing the wedged
+intermediaries with it.
+
+- Set `KUSTO_ENABLE_PARENT_WATCHDOG=false` to disable it.
+- It never blocks startup: if the process table can't be read, the watchdog
+  simply stays off.
+- Tradeoffs (accepted by design): liveness is keyed on PID against the startup
+  snapshot, so a PID reused within the poll window can be missed (the orphan
+  lingers, no worse than without the watchdog), and force-killing an ancestor
+  *above* the client (e.g. the editor host) while the client survives will also
+  stop the server. Use the disable switch if that matters for your setup.
 
 ## Read-Only Mode
 

--- a/src/common/parent-watchdog.ts
+++ b/src/common/parent-watchdog.ts
@@ -1,0 +1,232 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { criticalLog, debugLog } from './utils.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Windows-safe orphan detection for the stdio transport.
+ *
+ * The server is designed to exit when the MCP client closes stdin (see
+ * index.ts). That works on POSIX, but on Windows clients typically launch the
+ * server through intermediary processes — e.g. `cmd /c npx -y kusto-mcp@latest`,
+ * which itself spawns another `cmd` and `node`. Those intermediaries inherit the
+ * write end of the server's stdin and keep it open, so when the *client* dies
+ * the pipe is never closed: stdin never reaches EOF, `'end'`/`'close'` never
+ * fire, and the entire subtree is orphaned. The stranded server then sits on a
+ * half-dead pipe consuming CPU indefinitely.
+ *
+ * `process.ppid` cannot detect this because the *direct* parent (an intermediary
+ * cmd/node) stays alive. Instead we snapshot the full ancestor PID chain once at
+ * startup and periodically verify every ancestor still exists; the moment any
+ * link dies — which is what happens when the client/editor exits — we trigger a
+ * clean shutdown, releasing the wedged intermediaries with us.
+ *
+ * This is a best-effort *backstop* to the stdin-EOF handlers, not a replacement:
+ *   - It only arms on Windows (POSIX stdin EOF is reliable), and any failure to
+ *     read the process table simply disables it — it never blocks startup.
+ *   - Liveness is keyed on PID alone against the startup snapshot, so two edge
+ *     cases are accepted by design: (a) false negative — if a dead ancestor's
+ *     PID is reused within the poll window it reads as alive and the orphan
+ *     lingers (degrading to the pre-fix behaviour, no worse); (b) false positive
+ *     — the chain is walked to the OS root and any dead ancestor triggers
+ *     shutdown, so force-killing a grandparent (e.g. the editor host) while the
+ *     client survives also stops the server. The client PID cannot be identified
+ *     from the chain alone; `KUSTO_ENABLE_PARENT_WATCHDOG=false` is the opt-out.
+ *
+ * The runtime cost is one `process.kill(pid, 0)` per ancestor once a minute.
+ */
+
+const DEFAULT_INTERVAL_MS = 60_000;
+const MIN_INTERVAL_MS = 1_000;
+// Enumerating every process yields a large payload on busy hosts; give execFile
+// generous headroom so the snapshot is never truncated into a parse failure.
+const MAX_TABLE_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Walk the pid->ppid map from `startPid` up to the root, returning the ancestor
+ * PIDs (excluding `startPid` itself). Safe against missing links, non-positive
+ * roots, and cycles.
+ */
+export function computeAncestors(
+  startPid: number,
+  parentOf: ReadonlyMap<number, number>,
+): number[] {
+  const ancestors: number[] = [];
+  const seen = new Set<number>([startPid]);
+  let current = parentOf.get(startPid);
+  while (
+    current !== undefined &&
+    current > 0 &&
+    current !== startPid &&
+    !seen.has(current)
+  ) {
+    ancestors.push(current);
+    seen.add(current);
+    current = parentOf.get(current);
+  }
+  return ancestors;
+}
+
+/**
+ * Parse whitespace-separated "pid ppid" lines into a pid->ppid map. Both `ps`
+ * and the Windows CIM query below emit this shape; non-numeric lines (headers,
+ * blanks) are ignored.
+ */
+export function parseProcessTable(output: string): Map<number, number> {
+  const map = new Map<number, number>();
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.trim().match(/^(\d+)\s+(\d+)$/);
+    if (match) {
+      map.set(Number(match[1]), Number(match[2]));
+    }
+  }
+  return map;
+}
+
+async function readProcessTable(): Promise<Map<number, number>> {
+  if (process.platform === 'win32') {
+    // Resolve powershell.exe by ABSOLUTE path. A bare "powershell.exe" is
+    // resolved by libuv starting at the current working directory, which for an
+    // MCP server is often an untrusted workspace — a malicious powershell.exe
+    // dropped there would be executed at startup. An absolute path skips that
+    // search entirely (and falls safe: if absent, the read fails and the
+    // watchdog simply disables).
+    const root = process.env.SystemRoot || process.env.windir || 'C:\\Windows';
+    const powershell = `${root}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+    // One-shot CIM query -> "pid ppid" per line. Avoids the deprecated `wmic`.
+    const { stdout } = await execFileAsync(
+      powershell,
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        'Get-CimInstance Win32_Process | ForEach-Object { "$($_.ProcessId) $($_.ParentProcessId)" }',
+      ],
+      { encoding: 'utf8', timeout: 5_000, windowsHide: true, maxBuffer: MAX_TABLE_BYTES },
+    );
+    return parseProcessTable(stdout);
+  }
+  // POSIX: `ps` lists every process as "pid ppid". (Not reached in production —
+  // startParentWatchdog only reads the table on win32 — but kept platform-
+  // agnostic so the module is usable/testable anywhere.)
+  const { stdout } = await execFileAsync('ps', ['-Ao', 'pid=,ppid='], {
+    encoding: 'utf8',
+    timeout: 5_000,
+    maxBuffer: MAX_TABLE_BYTES,
+  });
+  return parseProcessTable(stdout);
+}
+
+export function defaultIsAlive(pid: number): boolean {
+  try {
+    // Signal 0 performs existence/permission checks without delivering a signal.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists but is owned by another user — still alive.
+    // Anything else (notably ESRCH) means it is gone.
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+export interface ParentWatchdogOptions {
+  /** Poll interval in ms. Defaults to KUSTO_PARENT_WATCHDOG_INTERVAL_MS or 60s. */
+  intervalMs?: number;
+  /** Liveness probe; overridable for tests. Defaults to `process.kill(pid, 0)`. */
+  isAlive?: (pid: number) => boolean;
+  /** Pre-resolved ancestor PIDs; overridable for tests. */
+  ancestors?: number[];
+  /** Process-table reader; overridable for tests. Defaults to the OS query. */
+  readProcessTable?: () => Promise<Map<number, number>> | Map<number, number>;
+}
+
+/**
+ * Start the orphan watchdog. Resolves to a stop function (also handy for tests).
+ * Resolves to a no-op when disabled, when running on a platform where stdin EOF
+ * already suffices (non-Windows), or when no ancestors can be resolved.
+ */
+export async function startParentWatchdog(
+  onOrphaned: (deadAncestorPid: number) => void,
+  options: ParentWatchdogOptions = {},
+): Promise<() => void> {
+  if (!isEnabled()) {
+    debugLog('Parent watchdog disabled via KUSTO_ENABLE_PARENT_WATCHDOG');
+    return () => {};
+  }
+
+  let ancestors = options.ancestors;
+  if (!ancestors) {
+    const readTable = options.readProcessTable;
+    // The stdin-EOF handlers already cover disconnects on POSIX; only Windows
+    // needs the ancestor snapshot. (An injected reader bypasses the gate so the
+    // read/error paths remain testable on Linux CI.)
+    if (!readTable && process.platform !== 'win32') {
+      debugLog('Parent watchdog inactive (non-Windows: stdin EOF is reliable)');
+      return () => {};
+    }
+    try {
+      ancestors = computeAncestors(
+        process.pid,
+        await (readTable ?? readProcessTable)(),
+      );
+    } catch (error) {
+      debugLog(
+        `Parent watchdog disabled (could not read process table): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return () => {};
+    }
+  }
+
+  if (ancestors.length === 0) {
+    debugLog('Parent watchdog disabled (no ancestors resolved)');
+    return () => {};
+  }
+
+  const watched = ancestors;
+  const isAlive = options.isAlive ?? defaultIsAlive;
+  const intervalMs = resolveIntervalMs(options.intervalMs);
+
+  debugLog(
+    `Parent watchdog armed (ancestors=[${watched.join(
+      ', ',
+    )}], interval=${intervalMs}ms)`,
+  );
+
+  const timer = setInterval(() => {
+    for (const pid of watched) {
+      if (!isAlive(pid)) {
+        criticalLog(
+          `Ancestor process ${pid} exited; MCP client is gone, shutting down`,
+        );
+        clearInterval(timer);
+        onOrphaned(pid);
+        return;
+      }
+    }
+  }, intervalMs);
+
+  // Never keep an otherwise-idle event loop alive on the watchdog's account.
+  timer.unref();
+
+  return () => clearInterval(timer);
+}
+
+function isEnabled(): boolean {
+  // Default on; mirror the negative-form parsing of KUSTO_ALLOW_WRITE_OPERATIONS.
+  const value = process.env.KUSTO_ENABLE_PARENT_WATCHDOG?.toLowerCase();
+  return !(value === 'false' || value === '0' || value === 'no');
+}
+
+export function resolveIntervalMs(override?: number): number {
+  if (typeof override === 'number' && Number.isFinite(override)) {
+    return Math.max(MIN_INTERVAL_MS, override);
+  }
+  const raw = process.env.KUSTO_PARENT_WATCHDOG_INTERVAL_MS;
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.max(MIN_INTERVAL_MS, parsed)
+    : DEFAULT_INTERVAL_MS;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   startTelemetry,
 } from './common/telemetry.js';
 import { createKustoServer } from './server.js';
+import { startParentWatchdog } from './common/parent-watchdog.js';
 import { VERSION } from './common/version.js';
 import {
   AuthenticationMethod,
@@ -226,6 +227,10 @@ async function runServer() {
   transport.onclose = onDisconnect;
   process.stdin.once('end', onDisconnect);
   process.stdin.once('close', onDisconnect);
+  // Defence-in-depth: a broken stdin pipe surfaces as an 'error' on some
+  // platforms. Harmless to treat as a disconnect; not a substitute for the
+  // watchdog below (the Windows orphan case leaves the pipe *healthy*).
+  process.stdin.once('error', onDisconnect);
   await server.connect(transport);
 
   criticalLog('Kusto MCP Server running on stdio');
@@ -233,6 +238,15 @@ async function runServer() {
     'service.version': VERSION,
     'kustomcp.config.autoconnect': autoConnect,
   });
+
+  // Windows-safe orphan detection. On Windows the client launches us through
+  // intermediary processes (cmd/npx) that inherit and hold stdin's write end,
+  // so when the client dies the handlers above never fire, the server is
+  // orphaned, and it spins on the half-dead pipe burning CPU indefinitely.
+  // Watch the ancestor PID chain and shut down if any link (i.e. the client)
+  // vanishes. Armed AFTER connect so the (async) process-table snapshot never
+  // delays the MCP handshake. See common/parent-watchdog.ts for the rationale.
+  await startParentWatchdog(() => void shutdownAndExit('parent-exited'));
 }
 
 // Start the server

--- a/tests/unit/suites/parent-watchdog.test.ts
+++ b/tests/unit/suites/parent-watchdog.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Orphan watchdog — Windows-safe disconnect detection. On Windows the MCP
+ * client launches the server through intermediary cmd/npx processes that hold
+ * stdin's write end open, so stdin never reaches EOF when the client dies and
+ * the server is orphaned (spinning on a dead pipe, burning CPU). The watchdog
+ * snapshots the ancestor PID chain and exits when any ancestor disappears.
+ *
+ * These tests exercise the pure logic (chain walking, table parsing, interval
+ * resolution, liveness probe) and the timer loop with injected dependencies, so
+ * they run deterministically on any platform without spawning real processes.
+ */
+
+import {
+  computeAncestors,
+  defaultIsAlive,
+  parseProcessTable,
+  resolveIntervalMs,
+  startParentWatchdog,
+} from '../../../src/common/parent-watchdog.js';
+
+describe('parent-watchdog', () => {
+  describe('parseProcessTable', () => {
+    it('parses "pid ppid" lines and ignores headers/blank/garbage', () => {
+      const map = parseProcessTable(
+        'PID PPID\n100 1\n  200 100 \n\ngarbage line\n300 200\n',
+      );
+      expect(map.get(100)).toBe(1);
+      expect(map.get(200)).toBe(100);
+      expect(map.get(300)).toBe(200);
+      expect(map.size).toBe(3);
+    });
+  });
+
+  describe('computeAncestors', () => {
+    it('walks from the start pid up to the root', () => {
+      const map = new Map<number, number>([
+        [500, 400],
+        [400, 300],
+        [300, 1],
+      ]);
+      expect(computeAncestors(500, map)).toEqual([400, 300, 1]);
+    });
+
+    it('stops on missing links and non-positive roots', () => {
+      expect(computeAncestors(10, new Map([[10, 0]]))).toEqual([]);
+      expect(computeAncestors(10, new Map())).toEqual([]);
+    });
+
+    it('is cycle-safe', () => {
+      expect(
+        computeAncestors(
+          10,
+          new Map([
+            [10, 20],
+            [20, 10],
+          ]),
+        ),
+      ).toEqual([20]);
+    });
+  });
+
+  describe('defaultIsAlive', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('reports the current process as alive', () => {
+      expect(defaultIsAlive(process.pid)).toBe(true);
+    });
+
+    it('treats EPERM (process owned by another user) as alive', () => {
+      jest.spyOn(process, 'kill').mockImplementation(() => {
+        const err: NodeJS.ErrnoException = new Error('operation not permitted');
+        err.code = 'EPERM';
+        throw err;
+      });
+      expect(defaultIsAlive(999999)).toBe(true);
+    });
+
+    it('treats ESRCH (no such process) as dead', () => {
+      jest.spyOn(process, 'kill').mockImplementation(() => {
+        const err: NodeJS.ErrnoException = new Error('no such process');
+        err.code = 'ESRCH';
+        throw err;
+      });
+      expect(defaultIsAlive(999999)).toBe(false);
+    });
+
+    it('treats an unknown error as dead', () => {
+      jest.spyOn(process, 'kill').mockImplementation(() => {
+        throw new Error('weird');
+      });
+      expect(defaultIsAlive(999999)).toBe(false);
+    });
+  });
+
+  describe('resolveIntervalMs', () => {
+    afterEach(() => {
+      delete process.env.KUSTO_PARENT_WATCHDOG_INTERVAL_MS;
+    });
+
+    it('clamps explicit overrides to the minimum', () => {
+      expect(resolveIntervalMs(250)).toBe(1000);
+      expect(resolveIntervalMs(60_000)).toBe(60_000);
+    });
+
+    it('reads and clamps the env var when no override is given', () => {
+      process.env.KUSTO_PARENT_WATCHDOG_INTERVAL_MS = '250';
+      expect(resolveIntervalMs()).toBe(1000);
+      process.env.KUSTO_PARENT_WATCHDOG_INTERVAL_MS = '30000';
+      expect(resolveIntervalMs()).toBe(30_000);
+    });
+
+    it.each(['abc', '', '0', '-5'])(
+      'falls back to the 60s default for invalid env value %p',
+      value => {
+        process.env.KUSTO_PARENT_WATCHDOG_INTERVAL_MS = value;
+        expect(resolveIntervalMs()).toBe(60_000);
+      },
+    );
+  });
+
+  describe('startParentWatchdog', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+      delete process.env.KUSTO_ENABLE_PARENT_WATCHDOG;
+      delete process.env.KUSTO_PARENT_WATCHDOG_INTERVAL_MS;
+    });
+
+    it('fires onOrphaned exactly once when an ancestor dies, then stops', async () => {
+      const dead = new Set<number>();
+      const onOrphaned = jest.fn();
+      await startParentWatchdog(onOrphaned, {
+        ancestors: [100, 200],
+        intervalMs: 1000,
+        isAlive: pid => !dead.has(pid),
+      });
+
+      jest.advanceTimersByTime(1000);
+      expect(onOrphaned).not.toHaveBeenCalled();
+
+      dead.add(200);
+      jest.advanceTimersByTime(1000);
+      expect(onOrphaned).toHaveBeenCalledWith(200);
+      expect(onOrphaned).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(5000);
+      expect(onOrphaned).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns a stop() that cancels the watchdog', async () => {
+      const onOrphaned = jest.fn();
+      const stop = await startParentWatchdog(onOrphaned, {
+        ancestors: [100],
+        intervalMs: 1000,
+        isAlive: () => false,
+      });
+      stop();
+      jest.advanceTimersByTime(5000);
+      expect(onOrphaned).not.toHaveBeenCalled();
+    });
+
+    it.each(['false', '0', 'no', 'FALSE'])(
+      'is a no-op when disabled via KUSTO_ENABLE_PARENT_WATCHDOG=%p',
+      async value => {
+        process.env.KUSTO_ENABLE_PARENT_WATCHDOG = value;
+        const onOrphaned = jest.fn();
+        await startParentWatchdog(onOrphaned, {
+          ancestors: [100],
+          intervalMs: 1000,
+          isAlive: () => false,
+        });
+        jest.advanceTimersByTime(5000);
+        expect(onOrphaned).not.toHaveBeenCalled();
+      },
+    );
+
+    it('arms when KUSTO_ENABLE_PARENT_WATCHDOG is truthy/unset', async () => {
+      process.env.KUSTO_ENABLE_PARENT_WATCHDOG = 'true';
+      const onOrphaned = jest.fn();
+      await startParentWatchdog(onOrphaned, {
+        ancestors: [100],
+        intervalMs: 1000,
+        isAlive: () => false,
+      });
+      jest.advanceTimersByTime(1000);
+      expect(onOrphaned).toHaveBeenCalledWith(100);
+    });
+
+    it('is a no-op when no ancestors resolve', async () => {
+      const onOrphaned = jest.fn();
+      await startParentWatchdog(onOrphaned, {
+        ancestors: [],
+        intervalMs: 1000,
+        isAlive: () => false,
+      });
+      jest.advanceTimersByTime(5000);
+      expect(onOrphaned).not.toHaveBeenCalled();
+    });
+
+    it('disables (never fires, never throws) when the process-table read fails', async () => {
+      const onOrphaned = jest.fn();
+      const stop = await startParentWatchdog(onOrphaned, {
+        intervalMs: 1000,
+        isAlive: () => false,
+        readProcessTable: () => {
+          throw new Error('boom');
+        },
+      });
+      jest.advanceTimersByTime(5000);
+      expect(onOrphaned).not.toHaveBeenCalled();
+      expect(typeof stop).toBe('function');
+    });
+
+    it('resolves ancestors from an injected process-table reader', async () => {
+      const onOrphaned = jest.fn();
+      const dead = new Set<number>();
+      // process.pid -> 4242 -> 1 ; watch the chain, then kill 4242.
+      await startParentWatchdog(onOrphaned, {
+        intervalMs: 1000,
+        isAlive: pid => !dead.has(pid),
+        readProcessTable: () =>
+          new Map<number, number>([
+            [process.pid, 4242],
+            [4242, 1],
+          ]),
+      });
+      jest.advanceTimersByTime(1000);
+      expect(onOrphaned).not.toHaveBeenCalled();
+      dead.add(4242);
+      jest.advanceTimersByTime(1000);
+      expect(onOrphaned).toHaveBeenCalledWith(4242);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #180.

## Problem

On Windows, orphaned `kusto-mcp` servers spin on a half-closed stdin pipe and leak CPU indefinitely after the MCP client exits (observed: 7 orphans at ~3 CPU-hours each, ~50% of total CPU, alive 21h). The existing disconnect signals (`stdin` `'end'`/`'close'`, `transport.onclose`) never fire because intermediary launch processes (`cmd`/`npx`) inherit and hold stdin's write end. `process.ppid` doesn't help — the direct parent stays alive. Full analysis in #180.

## Fix

Add an **ancestor-chain liveness check** as an additional disconnect signal feeding the *existing* `shutdownAndExit` path:

- Snapshot the full ancestor PID chain once at startup.
- Poll (default **60s**, `unref`'d) that every ancestor still exists via `process.kill(pid, 0)`.
- When any link dies (i.e. the client/editor exited), shut down cleanly — which also releases the wedged intermediaries.

## Design notes

- **Non-blocking startup:** the process-table snapshot is async and armed *after* `server.connect()`, so it never delays the MCP handshake.
- **Windows-only acquisition:** POSIX stdin EOF is reliable, so the snapshot/poll only arms on `win32`. (`parseProcessTable`/`computeAncestors` stay platform-agnostic for tests.)
- **Safe binary resolution:** `powershell.exe` is resolved by absolute path (`%SystemRoot%\System32\...`) to avoid libuv's CWD-first lookup executing a workspace-dropped `powershell.exe`.
- **Best-effort:** any failure to read the process table disables the check; it never prevents startup (mirrors the telemetry pattern).
- **Laptop-friendly:** a coarse, unref'd 60s check (one `kill(pid,0)` per ancestor) — no per-tick spawning, no wakeups during sleep.
- **Defence-in-depth:** also treats a `stdin` `'error'` as a disconnect.
- **Tunable / documented:** `KUSTO_ENABLE_PARENT_WATCHDOG` (default on) and `KUSTO_PARENT_WATCHDOG_INTERVAL_MS` (default 60000, min 1000), documented in `docs/CONFIGURATION.md` and `.env.example`, including the PID-reuse (false-negative) and full-chain (false-positive) tradeoffs.

## Testing

- `npm run build` ✓
- `npm run lint` ✓
- New unit tests (24) cover chain walking, table parsing, `defaultIsAlive` (incl. EPERM-as-alive / ESRCH-as-dead), interval resolution/clamping, the enable flag, the fires-once-then-stops loop, `stop()`, and the error-disable seam.
- Full unit suite green (a few pre-existing `machine-id` failures are environmental — they assert a first-ever-connection state and fail on a machine that has already run kusto-mcp; unrelated to this change).
