### PR TITLE
feat(telemetry): record uncaught exceptions and unhandled rejections

### DIFF
--- a/src/common/telemetry.ts
+++ b/src/common/telemetry.ts
@@ -312,6 +312,11 @@ export const connectionFailuresCounter = lazyCounter(
   'kustomcp.connection.failures',
   { unit: '{failure}', description: 'Connection initialization failures' },
 );
+export const processFatalCounter = lazyCounter('kustomcp.process.fatal', {
+  unit: '{error}',
+  description:
+    'Uncaught exceptions / unhandled rejections that ended the process',
+});
 
 export const toolDurationHistogram = lazyHistogram('kustomcp.tool.duration', {
   unit: 'ms',
@@ -339,3 +344,44 @@ export const responseBytesHistogram = lazyHistogram('kustomcp.response.bytes', {
   unit: 'By',
   description: 'Serialized MCP tool response size',
 });
+
+/**
+ * Record a process-ending failure before shutdown.
+ *
+ * The orphaned-server spin (#180, #196) burned a CPU core on thousands of
+ * machines and left no trace here at all — the crash handlers only wrote to
+ * stderr, and the spin starved the exporters. Two users had to count orphans
+ * with `ps` because we gave them no other way to see it. This makes that class
+ * of failure countable.
+ *
+ * Anonymity follows `recordSpanError`: the error *class* and, when present, the
+ * Node error `code` (`EPIPE`, `ECONNRESET`, ...). Never the message or stack —
+ * both can echo query text or identifiers.
+ *
+ * Never throws: this runs on the crash path, where a second failure is exactly
+ * what turned a clean exit into an infinite loop last time.
+ */
+export function recordProcessFatal(
+  kind: 'uncaughtException' | 'unhandledRejection',
+  error: unknown,
+): void {
+  try {
+    const attributes: Attributes = {
+      'kustomcp.fatal.kind': kind,
+      'kustomcp.error.type':
+        error instanceof Error && error.name ? error.name : 'Error',
+    };
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (typeof code === 'string') attributes['kustomcp.error.code'] = code;
+
+    processFatalCounter.add(1, attributes);
+    emitLog(
+      SeverityNumber.ERROR,
+      'ERROR',
+      'Process terminating on fatal error',
+      attributes,
+    );
+  } catch {
+    /* telemetry must never make a crash worse */
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { loadOrCreateMachineId } from './common/machine-id.js';
 import {
   SeverityNumber,
   emitLog,
+  recordProcessFatal,
   shutdownOtel,
   startTelemetry,
 } from './common/telemetry.js';
@@ -260,6 +261,7 @@ process.on('SIGTERM', () => void shutdownAndExit('SIGTERM'));
 
 // Handle uncaught exceptions
 process.on('uncaughtException', error => {
+  recordProcessFatal('uncaughtException', error);
   criticalLog(`Uncaught exception: ${error.message}`);
   criticalLog(error.stack || 'No stack trace available');
   void shutdownAndExit('uncaughtException', 1);
@@ -267,6 +269,7 @@ process.on('uncaughtException', error => {
 
 // Handle unhandled promise rejections
 process.on('unhandledRejection', reason => {
+  recordProcessFatal('unhandledRejection', reason);
   criticalLog(
     `Unhandled promise rejection: ${
       reason instanceof Error ? reason.message : String(reason)

--- a/tests/unit/suites/process-fatal.test.ts
+++ b/tests/unit/suites/process-fatal.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Process-fatal telemetry (#180, #196 follow-up).
+ *
+ * The orphan spin ran on thousands of machines and produced zero telemetry:
+ * the crash handlers wrote only to stderr, and the spin starved the exporters.
+ * `recordProcessFatal` makes that class of failure countable.
+ *
+ * Two properties matter more than the happy path, and both are pinned here:
+ * it must not leak error messages or stacks, and it must not throw — it runs
+ * on the crash path, where a second failure is what caused the loop.
+ */
+
+import { recordProcessFatal } from '../../../src/common/telemetry.js';
+
+type Attrs = Record<string, unknown> | undefined;
+type Recorded = { value?: number; message?: string; attributes?: Attrs };
+
+// Factories must not close over test-file variables, so each mock owns its
+// sink and exposes it on the mocked module.
+jest.mock('@opentelemetry/api', () => {
+  const actual = jest.requireActual('@opentelemetry/api');
+  const sink: Recorded[] = [];
+  return {
+    ...actual,
+    __added: sink,
+    trace: { ...actual.trace, getActiveSpan: () => undefined },
+    metrics: {
+      getMeter: () => ({
+        createCounter: () => ({
+          add: (value: number, attributes: Attrs) =>
+            sink.push({ value, attributes }),
+        }),
+        createHistogram: () => ({ record: () => {} }),
+      }),
+    },
+  };
+});
+
+jest.mock('@opentelemetry/api-logs', () => {
+  const actual = jest.requireActual('@opentelemetry/api-logs');
+  const sink: Recorded[] = [];
+  return {
+    ...actual,
+    __logged: sink,
+    logs: {
+      getLogger: () => ({
+        emit: (r: { body: string; attributes: Attrs }) =>
+          sink.push({ message: r.body, attributes: r.attributes }),
+      }),
+    },
+  };
+});
+
+const addedSink = (
+  jest.requireMock('@opentelemetry/api') as { __added: Recorded[] }
+).__added;
+const loggedSink = (
+  jest.requireMock('@opentelemetry/api-logs') as { __logged: Recorded[] }
+).__logged;
+
+describe('recordProcessFatal', () => {
+  beforeEach(() => {
+    addedSink.length = 0;
+    loggedSink.length = 0;
+  });
+
+  it('counts the failure with its kind and error class', () => {
+    recordProcessFatal('uncaughtException', new TypeError('boom'));
+
+    expect(addedSink).toHaveLength(1);
+    expect(addedSink[0].value).toBe(1);
+    expect(addedSink[0].attributes).toMatchObject({
+      'kustomcp.fatal.kind': 'uncaughtException',
+      'kustomcp.error.type': 'TypeError',
+    });
+  });
+
+  it('captures the errno code, which is what identifies a broken pipe', () => {
+    const err: NodeJS.ErrnoException = new Error('write EPIPE');
+    err.code = 'EPIPE';
+
+    recordProcessFatal('uncaughtException', err);
+
+    expect(addedSink[0].attributes).toMatchObject({
+      'kustomcp.error.code': 'EPIPE',
+    });
+  });
+
+  it('omits the code attribute when there is none', () => {
+    recordProcessFatal('unhandledRejection', new Error('plain'));
+
+    expect(addedSink[0].attributes).not.toHaveProperty('kustomcp.error.code');
+  });
+
+  it('never emits the error message or stack', () => {
+    const err = new Error('cluster=secret.kusto.windows.net user=alice@corp');
+
+    recordProcessFatal('uncaughtException', err);
+
+    const serialized = JSON.stringify({ addedSink, loggedSink });
+    expect(serialized).not.toContain('secret.kusto.windows.net');
+    expect(serialized).not.toContain('alice@corp');
+    expect(serialized).not.toContain('at Object');
+  });
+
+  it('emits an ERROR log alongside the counter', () => {
+    recordProcessFatal('unhandledRejection', new RangeError('nope'));
+
+    expect(loggedSink).toHaveLength(1);
+    expect(loggedSink[0].message).toBe('Process terminating on fatal error');
+    expect(loggedSink[0].attributes).toMatchObject({
+      'kustomcp.fatal.kind': 'unhandledRejection',
+      'kustomcp.error.type': 'RangeError',
+    });
+  });
+
+  it('tolerates non-Error rejection values', () => {
+    expect(() =>
+      recordProcessFatal('unhandledRejection', 'a string'),
+    ).not.toThrow();
+    expect(() =>
+      recordProcessFatal('unhandledRejection', undefined),
+    ).not.toThrow();
+    expect(addedSink[0].attributes).toMatchObject({
+      'kustomcp.error.type': 'Error',
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #210.

## Why

The orphaned-server spin (#180, #196) burned a CPU core on thousands of machines and produced **zero** telemetry. Three things hid it:

1. The `uncaughtException` / `unhandledRejection` handlers only wrote to stderr — no log, no metric, no span.
2. The spin starved the event loop, so the batch exporters never got a turn.
3. `shutdownAndExit` never reached `shutdownOtel()`, so nothing was flushed.

Across **204,286 recorded errors in 30 days** there was not a single entry for it. Two users had to count orphans by hand with `ps`, because we gave them no other way to see it.

## What

`recordProcessFatal()` counts the failure and emits an ERROR log *before* shutdown, so this class of failure becomes measurable instead of inferred from GitHub issues.

Attributes are the error class and, when present, the Node errno code (`EPIPE`, `ECONNRESET`) — the two fields that actually identify a broken pipe. Anonymity follows the existing `recordSpanError` rule: never the message or stack, since both can echo query text or identifiers.

The helper cannot throw. It runs on the crash path, where a second failure is precisely what turned a clean exit into an infinite loop last time.

## Verification

Against a local OTLP collector, on a real uncaught exception:

```
kustomcp.process.fatal
kustomcp.fatal.kind = uncaughtException
kustomcp.error.code = EPIPE
"Process terminating on fatal error"
```

with no trace of the error message or stack anywhere in the exported payload (grepped for both).

- 189/189 unit tests, lint 0 errors
- Red→green confirmed: removing the counter fails 4 of the 6 new tests
- Tests pin the two properties that matter most — no message/stack leakage, and never throwing on non-`Error` rejection values

## Scope note

This is **forward-looking, not a retroactive safety net.** Now that #210 is in, client death exits cleanly via `stdin` EOF and never raises an uncaught exception — so this instrumentation would not have caught the original bug. Its value is that the *next* fatal crash class shows up in a dashboard instead of in someone's `ps` output.